### PR TITLE
feat: ignored files

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,6 +194,10 @@ impl Linter {
         check_only_rules: RuleFilter,
     ) -> Result<Vec<LintOutput>> {
         if path.is_file() {
+            if self.config.is_ignored(path) {
+                return Ok(Vec::new());
+            }
+
             let mut file = fs::File::open(path)?;
             let mut contents = String::new();
             file.read_to_string(&mut contents)?;
@@ -269,8 +273,10 @@ impl LinterBuilder {
     #[wasm_bindgen]
     #[cfg(target_arch = "wasm32")]
     pub fn configure(self, config: JsValue) -> LinterBuilderWithConfig {
+        use config::ConfigDir;
+
         let settings: toml::Value = serde_wasm_bindgen::from_value(config).unwrap();
-        let config = Config::from_serializable(settings).unwrap();
+        let config = Config::from_serializable(settings, &ConfigDir(None)).unwrap();
         LinterBuilderWithConfig { config }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,9 +77,9 @@ fn execute() -> Result<Result<()>> {
     );
     debug!("Config path is {config_path:?}");
 
-    let linter = LinterBuilder::new()
-        .configure(Config::from_config_file(config_path)?)
-        .build()?;
+    let config = Config::from_config_file(config_path)?;
+    debug!("Config: {config:?}");
+    let linter = LinterBuilder::new().configure(config).build()?;
     debug!("Linter built: {linter:?}");
 
     let mut diagnostics = Vec::new();

--- a/tests/good00x.mdx
+++ b/tests/good00x.mdx
@@ -1,0 +1,1 @@
+# Lorem ipsum

--- a/tests/supa-mdx-lint.config.toml
+++ b/tests/supa-mdx-lint.config.toml
@@ -1,2 +1,4 @@
+ignore_patterns = ["*00x.mdx"]
+
 [Rule001HeadingCase]
 may_uppercase = ["Supabase"]


### PR DESCRIPTION
Specify ignored files as an array of glob patterns, using the `ignore_patterns` key in the configuration file.