### PR TITLE
feat: error levels

### DIFF
--- a/src/output/rdf.rs
+++ b/src/output/rdf.rs
@@ -12,7 +12,7 @@ use std::io::Write;
 
 use anyhow::Result;
 use log::{debug, warn};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 use crate::{
     document::{AdjustedPoint, Location},
@@ -23,22 +23,22 @@ use super::{LintOutput, OutputFormatter};
 
 pub struct RdfFormatter;
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize)]
 struct RdfOutput<'output> {
     message: &'output str,
     location: RdfLocation<'output>,
-    severity: LintLevel,
+    severity: &'output LintLevel,
     #[serde(skip_serializing_if = "Option::is_none")]
     suggestions: Option<Vec<RdfSuggestion<'output>>>,
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize)]
 struct RdfLocation<'location> {
     path: &'location str,
     range: RdfRange,
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize)]
 struct RdfRange {
     start: RdfPosition,
     end: RdfPosition,
@@ -53,7 +53,7 @@ impl From<&Location> for RdfRange {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize)]
 struct RdfPosition {
     line: usize,
     column: usize,
@@ -68,7 +68,7 @@ impl From<&AdjustedPoint> for RdfPosition {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize)]
 struct RdfSuggestion<'suggestion> {
     range: RdfRange,
     text: &'suggestion str,
@@ -109,7 +109,7 @@ impl OutputFormatter for RdfFormatter {
                         path: &output.file_path,
                         range: (&error.location).into(),
                     },
-                    severity: LintLevel::Error,
+                    severity: &error.level,
                     suggestions: error
                         .fix
                         .as_ref()
@@ -147,6 +147,7 @@ mod tests {
     fn test_rdf_formatter() {
         let file_path = "test.md".to_string();
         let error = LintError {
+            level: LintLevel::Error,
             message: "This is an error".to_string(),
             location: Location::dummy(1, 1, 0, 1, 2, 1),
             fix: None,
@@ -172,6 +173,7 @@ mod tests {
     fn test_rdf_formatter_with_fixes() {
         let file_path = "test.md".to_string();
         let error = LintError {
+            level: LintLevel::Error,
             message: "This is an error".to_string(),
             location: Location::dummy(1, 1, 0, 1, 9, 8),
             fix: Some(vec![LintFix::Delete(crate::errors::LintFixDelete {
@@ -198,11 +200,13 @@ mod tests {
     fn test_rdf_formatter_multiple_errors() {
         let file_path = "test.md".to_string();
         let error_1 = LintError {
+            level: LintLevel::Error,
             message: "This is an error".to_string(),
             location: Location::dummy(1, 1, 0, 1, 2, 1),
             fix: None,
         };
         let error_2 = LintError {
+            level: LintLevel::Error,
             message: "This is another error".to_string(),
             location: Location::dummy(2, 1, 10, 2, 2, 11),
             fix: None,
@@ -229,11 +233,13 @@ mod tests {
     fn test_rdf_formatter_multiple_files() {
         let file_path_1 = "test.md".to_string();
         let error_1 = LintError {
+            level: LintLevel::Error,
             message: "This is an error".to_string(),
             location: Location::dummy(1, 1, 0, 1, 2, 1),
             fix: None,
         };
         let error_2 = LintError {
+            level: LintLevel::Error,
             message: "This is another error".to_string(),
             location: Location::dummy(2, 1, 10, 2, 2, 11),
             fix: None,

--- a/src/rules/rule001_heading_case.rs
+++ b/src/rules/rule001_heading_case.rs
@@ -4,7 +4,7 @@ use supa_mdx_macros::RuleName;
 
 use crate::{
     document::{Location, Point, UnadjustedPoint},
-    errors::{LintError, LintFix, LintFixReplace},
+    errors::{LintError, LintFix, LintFixReplace, LintLevel},
     utils::{split_first_word, HasChildren},
 };
 
@@ -21,6 +21,10 @@ pub struct Rule001HeadingCase {
 }
 
 impl Rule for Rule001HeadingCase {
+    fn default_level(&self) -> LintLevel {
+        LintLevel::Error
+    }
+
     fn setup(&mut self, settings: Option<&RuleSettings>) {
         if let Some(settings) = settings {
             let regex_settings = RegexSettings {
@@ -39,7 +43,7 @@ impl Rule for Rule001HeadingCase {
         }
     }
 
-    fn check(&self, ast: &Node, context: &RuleContext) -> Option<Vec<LintError>> {
+    fn check(&self, ast: &Node, context: &RuleContext, level: LintLevel) -> Option<Vec<LintError>> {
         if !matches!(ast, Node::Heading(_)) {
             return None;
         };
@@ -51,7 +55,13 @@ impl Rule for Rule001HeadingCase {
         let lint_error = if fixes.is_empty() {
             None
         } else {
-            LintError::from_node_with_fix(ast, context, "Heading should be sentence case", fixes)
+            LintError::from_node_with_fix(
+                ast,
+                context,
+                "Heading should be sentence case",
+                level,
+                fixes,
+            )
         };
 
         lint_error.map(|lint_error| vec![lint_error])
@@ -290,7 +300,7 @@ mod tests {
         let heading = create_heading_node("This is a correct heading", 1);
         let context = create_rule_context();
 
-        let result = rule.check(&heading, &context);
+        let result = rule.check(&heading, &context, LintLevel::Error);
         assert!(result.is_none());
     }
 
@@ -300,7 +310,7 @@ mod tests {
         let heading = create_heading_node("this should fail", 1);
         let context = create_rule_context();
 
-        let result = rule.check(&heading, &context);
+        let result = rule.check(&heading, &context, LintLevel::Error);
         assert!(result.is_some());
 
         let errors = result.unwrap();
@@ -333,7 +343,7 @@ mod tests {
         let heading = create_heading_node("This Should Fail", 1);
         let context = create_rule_context();
 
-        let result = rule.check(&heading, &context);
+        let result = rule.check(&heading, &context, LintLevel::Error);
         assert!(result.is_some());
 
         let errors = result.unwrap();
@@ -383,7 +393,7 @@ mod tests {
         let heading = create_heading_node("This is an API heading", 1);
         let context = create_rule_context();
 
-        let result = rule.check(&heading, &context);
+        let result = rule.check(&heading, &context, LintLevel::Error);
         assert!(result.is_none());
     }
 
@@ -396,7 +406,7 @@ mod tests {
         let heading = create_heading_node("the quick brown fox", 1);
         let context = create_rule_context();
 
-        let result = rule.check(&heading, &context);
+        let result = rule.check(&heading, &context, LintLevel::Error);
         assert!(result.is_none());
     }
 
@@ -409,7 +419,7 @@ mod tests {
         });
         let context = create_rule_context();
 
-        let result = rule.check(&paragraph, &context);
+        let result = rule.check(&paragraph, &context, LintLevel::Error);
         assert!(result.is_none());
     }
 
@@ -422,7 +432,7 @@ mod tests {
         let heading = create_heading_node("This is about New York City", 1);
         let context = create_rule_context();
 
-        let result = rule.check(&heading, &context);
+        let result = rule.check(&heading, &context, LintLevel::Error);
         assert!(result.is_none());
     }
 
@@ -436,7 +446,7 @@ mod tests {
         let heading = create_heading_node("This is about New York City", 1);
         let context = create_rule_context();
 
-        let result = rule.check(&heading, &context);
+        let result = rule.check(&heading, &context, LintLevel::Error);
         assert!(result.is_none());
     }
 
@@ -449,7 +459,7 @@ mod tests {
         let heading = create_heading_node("This is an API-related topic", 1);
         let context = create_rule_context();
 
-        let result = rule.check(&heading, &context);
+        let result = rule.check(&heading, &context, LintLevel::Error);
         assert!(result.is_none());
     }
 
@@ -462,7 +472,7 @@ mod tests {
         let heading = create_heading_node("the quick brown fox", 1);
         let context = create_rule_context();
 
-        let result = rule.check(&heading, &context);
+        let result = rule.check(&heading, &context, LintLevel::Error);
         assert!(result.is_none());
     }
 
@@ -475,7 +485,7 @@ mod tests {
         let heading = create_heading_node("This is an API call", 1);
         let context = create_rule_context();
 
-        let result = rule.check(&heading, &context);
+        let result = rule.check(&heading, &context, LintLevel::Error);
         assert!(result.is_some());
 
         let result = result.unwrap();
@@ -509,7 +519,7 @@ mod tests {
         let heading = create_heading_node("The basics of API authentication in OAuth", 1);
         let context = create_rule_context();
 
-        let result = rule.check(&heading, &context);
+        let result = rule.check(&heading, &context, LintLevel::Error);
         assert!(result.is_none());
     }
 }


### PR DESCRIPTION
Allow configuration of error levels for rules, which can be either `LintLevel::Error` or `LintLevel::Warning`.

This is configured via the `level` key in each rule's settings, which is now a reserved key. While it is available for rule setup to read if desired, trying to use this for other purposes will conflict with the error level logic.