### PR TITLE
fix(rule001): numbered headings

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -43,10 +43,14 @@ impl HasChildren for markdown::mdast::Link {
     }
 }
 
-pub fn split_first_word_at_whitespace_and_colons(s: &str) -> (&str, &str, bool) {
+pub fn is_recapitalizing_break(c: char) -> bool {
+    c == ':' || c == '.' || c == '!' || c == '?'
+}
+
+pub fn split_first_word_at_break(s: &str) -> (&str, &str, bool) {
     let next_whitespace = s.find(char::is_whitespace);
-    let next_colon = s.find(':');
-    match (next_whitespace, next_colon) {
+    let next_recapitalizing_break = s.find(is_recapitalizing_break);
+    match (next_whitespace, next_recapitalizing_break) {
         (Some(idx), None) => (&s[..idx], &s[idx..], false),
         (None, Some(idx)) => {
             if s[idx + 1..].starts_with(char::is_whitespace) {


### PR DESCRIPTION
Headings of the format `# 1. Do a thing` should be capitalized after the number