### PR TITLE
fix: add token for publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Download binary distributions
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #v4.1.8
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.inputs.run_id }}
           name: artifact-npm-binary-distributions
           path: ./npm-binary-distributions
@@ -26,6 +27,7 @@ jobs:
       - name: Download main Node package
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #v4.1.8
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.inputs.run_id }}
           name: artifact-pkg-node
           path: ./node-pkg


### PR DESCRIPTION
download-artifacts needs a token to download artifacts cross-workflow runs