### PR TITLE
fix: js wrapper bugs

### DIFF
--- a/packages/supa-mdx-lint/src/helper.js
+++ b/packages/supa-mdx-lint/src/helper.js
@@ -156,6 +156,13 @@ It seems like none of the "@supabase/supa-mdx-lint" package's optional dependenc
   }
 }
 
+class LinterError extends Error {
+  constructor(message, code) {
+    super(message);
+    this.code = code;
+  }
+}
+
 /**
  * Runs `supa-mdx-lint` with the given command line arguments.
  *
@@ -177,8 +184,16 @@ async function execute(args) {
     pid.on("error", (err) => {
       reject(err);
     });
-    pid.on("exit", () => {
-      resolve();
+    pid.on("exit", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        const error = new LinterError(
+          `supa-mdx-lint exited with code ${code}`,
+          code,
+        );
+        reject(error);
+      }
     });
   });
 }

--- a/packages/supa-mdx-lint/src/index.js
+++ b/packages/supa-mdx-lint/src/index.js
@@ -8,13 +8,12 @@ const helper = require("./helper");
 
 async function main() {
   const args = process.argv.slice(2);
-  await helper.execute(args);
+  try {
+    await helper.execute(args);
+  } catch (err) {
+    process.exit(err.code ?? 1);
+  }
 }
-
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
 
 if (require.main === module) {
   main();


### PR DESCRIPTION
- main getting called twice leading to the linter running twice by accident
- not passing along the exit code