### PR TITLE
fix: rdf output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -158,13 +158,20 @@ fn execute() -> Result<Result<()>> {
 
     if !args.silent {
         args.format.format(&diagnostics, &mut stdout)?;
-        let duration = start.elapsed().as_secs();
-        writeln!(
-            stdout,
-            "🕚 Done in {} second{}",
-            duration,
-            if duration == 1 { "" } else { "s" }
-        )?;
+        if args.format.should_log_metadata() {
+            let millis = start.elapsed().as_millis();
+            if millis < 1000 {
+                writeln!(stdout, "🕚 Done in {:.1} seconds", millis as f64 / 1000.0)?;
+            } else {
+                let seconds = millis / 1000;
+                writeln!(
+                    stdout,
+                    "🕚 Done in {} second{}",
+                    seconds,
+                    if seconds == 1 { "" } else { "s" }
+                )?;
+            }
+        }
     }
 
     stdout.flush()?;

--- a/src/output.rs
+++ b/src/output.rs
@@ -46,6 +46,14 @@ impl OutputFormatter {
             Self::Rdf(formatter) => formatter.format(output, io),
         }
     }
+
+    pub fn should_log_metadata(&self) -> bool {
+        match self {
+            Self::Pretty(formatter) => formatter.should_log_metadata(),
+            Self::Simple(formatter) => formatter.should_log_metadata(),
+            Self::Rdf(formatter) => formatter.should_log_metadata(),
+        }
+    }
 }
 
 impl FromStr for OutputFormatter {

--- a/src/output/pretty.rs
+++ b/src/output/pretty.rs
@@ -183,6 +183,10 @@ impl PrettyFormatter {
         writeln!(io, "{}", diagnostic_message)?;
         Ok(())
     }
+
+    pub(super) fn should_log_metadata(&self) -> bool {
+        true
+    }
 }
 
 #[cfg(test)]

--- a/src/output/rdf.rs
+++ b/src/output/rdf.rs
@@ -141,6 +141,10 @@ impl RdfFormatter {
 
         Ok(())
     }
+
+    pub(super) fn should_log_metadata(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/src/output/simple.rs
+++ b/src/output/simple.rs
@@ -58,6 +58,10 @@ impl SimpleFormatter {
 
         Ok(())
     }
+
+    pub(super) fn should_log_metadata(&self) -> bool {
+        true
+    }
 }
 
 impl SimpleFormatter {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -88,3 +88,14 @@ fn integration_test_multiple_targets() {
         .stdout(predicate::str::contains("2 sources linted"))
         .stdout(predicate::str::contains("Found 2 errors"));
 }
+
+#[test]
+fn integration_test_rdf_no_extra_logs() {
+    let mut cmd = Command::cargo_bin("supa-mdx-lint").unwrap();
+    cmd.arg("tests/good001.mdx")
+        .arg("--config")
+        .arg("tests/supa-mdx-lint.config.toml")
+        .arg("--format")
+        .arg("rdf");
+    cmd.assert().success().stdout(predicate::str::is_empty());
+}


### PR DESCRIPTION
RDF output should not return anything aside from the JSONL error messages. Remove the duration metadata log line for RDF.

Also improve the duration log by calculating milliseconds if duration < 1 second (before, it would often display "Done in 1 second" which is both misleading and useless).