### PR TITLE
feat: expand regex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,6 +584,7 @@ dependencies = [
  "markdown",
  "predicates",
  "regex",
+ "regex-syntax",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ itertools = "0.13.0"
 log = "0.4.22"
 markdown = "1.0.0-alpha.21"
 regex = "1.11.0"
+regex-syntax = { version = "0.8.5", features = ["std", "unicode-perl"] }
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.128"
 serde_yaml = "0.9.34"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use std::{
     env,
     io::{BufWriter, Write},
     path::PathBuf,
-    process::{self, ExitCode},
+    process::ExitCode,
     time::Instant,
 };
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,7 @@
+mod char_tree;
 pub(crate) mod mdast;
 pub(crate) mod path;
+pub(crate) mod regex;
 pub(crate) mod words;
 
 use std::path::Path;

--- a/src/utils/char_tree.rs
+++ b/src/utils/char_tree.rs
@@ -1,0 +1,187 @@
+#![allow(dead_code)]
+// The [mutable key lint](https://rust-lang.github.io/rust-clippy/master/index.html#mutable_key_type)
+// has known false positives when dealing with a struct that has only partial
+// interior mutability. In this module, CharNode has a children field that needs
+// interior mutability to build the tree, but it's hashed on the value field,
+// so the lint can be ignored.
+#![allow(clippy::mutable_key_type)]
+
+use std::{
+    cell::RefCell,
+    collections::HashSet,
+    hash::{Hash, Hasher},
+    rc::Rc,
+};
+
+#[derive(Debug, Eq, PartialEq, Hash)]
+enum NodeValue {
+    Initial,
+    Char(char),
+    /// The path leading up to this node is not a valid word and should be
+    /// abandoned
+    Abort,
+    /// The path leading up to this node is a complete word in and of itself
+    Finish,
+}
+
+#[derive(Debug)]
+struct CharNodeInner {
+    value: NodeValue,
+    children: RefCell<Option<HashSet<CharNode>>>,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct CharNode(Rc<CharNodeInner>);
+
+impl PartialEq for CharNode {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.value == other.0.value
+    }
+}
+
+impl Eq for CharNode {}
+
+impl Hash for CharNode {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.value.hash(state);
+    }
+}
+
+impl CharNode {
+    pub(super) fn initiate() -> Self {
+        Self(Rc::new(CharNodeInner {
+            value: NodeValue::Initial,
+            children: RefCell::new(None),
+        }))
+    }
+
+    fn new(value: char) -> Self {
+        Self(Rc::new(CharNodeInner {
+            value: NodeValue::Char(value),
+            children: RefCell::new(None),
+        }))
+    }
+
+    fn new_abort() -> Self {
+        Self(Rc::new(CharNodeInner {
+            value: NodeValue::Abort,
+            children: RefCell::new(None),
+        }))
+    }
+
+    fn new_finish() -> Self {
+        Self(Rc::new(CharNodeInner {
+            value: NodeValue::Finish,
+            children: RefCell::new(None),
+        }))
+    }
+
+    fn add_child(&mut self, child: CharNode) {
+        let mut children = self.0.children.borrow_mut();
+        let children_set = children.get_or_insert_with(HashSet::new);
+        children_set.insert(child);
+    }
+
+    pub(super) fn is_root(&self) -> bool {
+        self.0.value == NodeValue::Initial
+    }
+
+    pub(super) fn append(&mut self, value: char) -> Self {
+        let new_child = Self::new(value);
+        self.add_child(new_child.clone());
+        new_child
+    }
+
+    pub(super) fn abort(&mut self) {
+        let new_child = Self::new_abort();
+        self.add_child(new_child);
+    }
+
+    pub(super) fn mark_finished_word(&mut self) {
+        let new_child = Self::new_finish();
+        self.add_child(new_child);
+    }
+
+    pub(super) fn collect(&self) -> Vec<String> {
+        fn traverse(node: &CharNode, prefix: &str, result: &mut Vec<String>) {
+            match node.0.value {
+                NodeValue::Initial => {
+                    if let Some(children) = &*node.0.children.borrow() {
+                        let new_prefix = "";
+                        for child in children {
+                            traverse(child, new_prefix, result);
+                        }
+                    }
+                }
+                NodeValue::Char(value) => {
+                    let new_prefix = format!("{}{}", prefix, value);
+                    if let Some(children) = &*node.0.children.borrow() {
+                        for child in children {
+                            if child.0.value == NodeValue::Finish {
+                                result.push(new_prefix.clone());
+                            } else {
+                                traverse(child, &new_prefix, result);
+                            }
+                        }
+                    } else {
+                        result.push(new_prefix);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let mut result = Vec::new();
+        traverse(self, "", &mut result);
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_char_tree_collect() {
+        let mut root = CharNode::initiate();
+        let mut child1 = root.append('a');
+        let mut child2 = child1.append('b');
+        child1.append('c');
+        child2.append('d');
+
+        let collected = child1.collect();
+        assert_eq!(collected.len(), 2);
+        assert!(collected.contains(&"abd".to_string()));
+        assert!(collected.contains(&"ac".to_string()));
+    }
+
+    #[test]
+    fn test_char_tree_collect_with_aborts() {
+        let mut root = CharNode::initiate();
+        let mut child1 = root.append('a');
+        let mut child2 = child1.append('b');
+        child1.append('c');
+        child2.append('d');
+        let mut aborted_child = child2.append('e');
+        aborted_child.abort();
+
+        let collected = child1.collect();
+        assert_eq!(collected.len(), 2);
+        assert!(collected.contains(&"ac".to_string()));
+        assert!(collected.contains(&"abd".to_string()));
+    }
+
+    #[test]
+    fn test_char_tree_with_mid_path_finish() {
+        let mut root = CharNode::initiate();
+        let mut child1 = root.append('a');
+        let mut child2 = child1.append('b');
+        child2.mark_finished_word();
+        child2.append('c');
+
+        let collected = child1.collect();
+        assert_eq!(collected.len(), 2);
+        assert!(collected.contains(&"ab".to_string()));
+        assert!(collected.contains(&"abc".to_string()));
+    }
+}

--- a/src/utils/regex.rs
+++ b/src/utils/regex.rs
@@ -1,0 +1,242 @@
+#![allow(dead_code)]
+
+use regex_syntax::ast::{parse::Parser, Ast, ClassSet, ClassSetItem, Concat, RepetitionKind};
+
+use crate::utils::char_tree::CharNode;
+
+/// Expand a regex pattern into a list of strings.
+///
+/// Because of the nature of regex and wanting to return (a) a finite result
+/// in (b) some reasonable amount of time, the returned list of strings is _not_
+/// exhaustive. Even for a valid and theoretically finite regex pattern, None
+/// may be returned if a performant expansion is too difficult.
+///
+/// ```ignore
+/// let result = expand_regex(r"test(s|ed)?");
+/// assert_eq!(result, Some(vec!["test", "tests", "tested"]));
+/// ```
+pub fn expand_regex(pattern: &str) -> Option<Vec<String>> {
+    let ast = Parser::new().parse(pattern).ok()?;
+    expand_ast(&ast)
+}
+
+fn expand_ast(ast: &Ast) -> Option<Vec<String>> {
+    #[derive(Debug)]
+    enum NextNode {
+        Single(CharNode),
+        Multiple(Vec<CharNode>),
+    }
+
+    fn expand_ast_internal(ast: &Ast, char_tree: &mut Option<CharNode>) -> Option<NextNode> {
+        match ast {
+            Ast::Assertion(_) => {
+                // Assertions do not affect the possible strings
+                None
+            }
+            Ast::Literal(literal) => match char_tree {
+                Some(ref mut node) => {
+                    let new_node = node.append(literal.c);
+                    Some(NextNode::Single(new_node))
+                }
+                None => {
+                    let new_tree = char_tree.insert(CharNode::initiate());
+                    let new_node = new_tree.append(literal.c);
+                    Some(NextNode::Single(new_node))
+                }
+            },
+            Ast::ClassBracketed(class_bracketed) if !class_bracketed.negated => {
+                let new_nodes = expand_class_set(char_tree, &class_bracketed.kind);
+                new_nodes.map(NextNode::Multiple)
+            }
+            Ast::Repetition(repetition)
+                if matches!(repetition.op.kind, RepetitionKind::ZeroOrOne) =>
+            {
+                let mut tree = char_tree.get_or_insert_with(CharNode::initiate).clone();
+                if !tree.is_root() {
+                    tree.mark_finished_word();
+                }
+
+                let mut next_nodes = vec![tree.clone()];
+
+                let alt_branch = expand_ast_internal(repetition.ast.as_ref(), char_tree);
+                match alt_branch {
+                    Some(NextNode::Single(node)) if node != tree => {
+                        next_nodes.push(node);
+                    }
+                    Some(NextNode::Multiple(nodes)) => {
+                        for node in nodes.into_iter() {
+                            if node != tree {
+                                next_nodes.push(node);
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+
+                Some(NextNode::Multiple(next_nodes))
+            }
+            Ast::Group(group) => expand_ast_internal(group.ast.as_ref(), char_tree),
+            Ast::Alternation(alternation) => {
+                let mut next = Vec::new();
+
+                for ast in alternation.asts.iter() {
+                    match expand_ast_internal(ast, char_tree) {
+                        Some(NextNode::Single(node)) => next.push(node),
+                        Some(NextNode::Multiple(nodes)) => next.extend(nodes),
+                        _ => {}
+                    }
+                }
+
+                Some(NextNode::Multiple(next))
+            }
+            Ast::Concat(concat) => expand_concat(char_tree, concat),
+            _ => {
+                // Too complex to list all the possibilities, just abort
+                if let Some(ref mut node) = char_tree {
+                    node.abort();
+                }
+                None
+            }
+        }
+    }
+
+    fn expand_concat(char_tree: &mut Option<CharNode>, concat: &Concat) -> Option<NextNode> {
+        let tree = char_tree.get_or_insert_with(CharNode::initiate).clone();
+        let mut next_node = Some(NextNode::Single(tree));
+
+        for ast in concat.asts.iter() {
+            match next_node {
+                Some(NextNode::Single(node)) => {
+                    let mut node = Some(node);
+                    next_node = expand_ast_internal(ast, &mut node);
+                }
+                Some(NextNode::Multiple(nodes)) => {
+                    let mut next = Vec::new();
+
+                    nodes.into_iter().for_each(|node| {
+                        let mut node = Some(node);
+                        match expand_ast_internal(ast, &mut node) {
+                            Some(NextNode::Single(node)) => next.push(node),
+                            Some(NextNode::Multiple(nodes)) => next.extend(nodes),
+                            _ => {}
+                        }
+                    });
+
+                    next_node = Some(NextNode::Multiple(next));
+                }
+                _ => {}
+            }
+        }
+
+        next_node
+    }
+
+    fn expand_class_set(
+        char_tree: &mut Option<CharNode>,
+        class_set: &ClassSet,
+    ) -> Option<Vec<CharNode>> {
+        let mut result = None::<Vec<CharNode>>;
+
+        match class_set {
+            ClassSet::Item(ClassSetItem::Literal(literal)) => {
+                let tree = char_tree.get_or_insert_with(CharNode::initiate);
+                let new_node = tree.append(literal.c);
+                result.get_or_insert_with(Vec::new).push(new_node);
+            }
+            ClassSet::Item(ClassSetItem::Union(union)) => {
+                for item in union.items.iter() {
+                    let class_set = ClassSet::Item(item.clone());
+                    if let Some(new_nodes) = expand_class_set(char_tree, &class_set) {
+                        result.get_or_insert_with(Vec::new).extend(new_nodes);
+                    }
+                }
+            }
+            _ => {
+                // Too complex to list all the possibilities, just abort
+                if let Some(ref mut node) = char_tree {
+                    node.abort();
+                }
+            }
+        }
+
+        result
+    }
+
+    let mut char_tree = None::<CharNode>;
+    expand_ast_internal(ast, &mut char_tree);
+    char_tree.map(|tree| tree.collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_expand_regex_blank_returns_none() {
+        let result = expand_regex("");
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_expand_regex_literal_into_itself() {
+        let result = expand_regex("test");
+        assert_eq!(result, Some(vec!["test".to_string()]));
+
+        let result = expand_regex("whatchamacallit\\?");
+        assert_eq!(result, Some(vec!["whatchamacallit?".to_string()]));
+    }
+
+    #[test]
+    fn test_expand_regex_alternates() {
+        let mut result = expand_regex("test(s|ed)").unwrap();
+        result.sort();
+        assert_eq!(result, vec!["tested".to_string(), "tests".to_string()]);
+    }
+
+    #[test]
+    fn test_expand_regex_optional() {
+        let mut result = expand_regex("tests?").unwrap();
+        result.sort();
+        assert_eq!(result, vec!["test".to_string(), "tests".to_string()]);
+    }
+
+    #[test]
+    fn test_expand_regex_alternates_optional() {
+        let mut result = expand_regex("test(s|ed)?").unwrap();
+        result.sort();
+        assert_eq!(
+            result,
+            vec![
+                "test".to_string(),
+                "tested".to_string(),
+                "tests".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_expand_regex_alternates_class_set() {
+        let mut result = expand_regex("[Aa]pple").unwrap();
+        result.sort();
+        assert_eq!(result, vec!["Apple".to_string(), "apple".to_string()]);
+    }
+
+    #[test]
+    fn text_expand_regex_initial_optional() {
+        let mut result = expand_regex("(pre)?determine").unwrap();
+        result.sort();
+        assert_eq!(
+            result,
+            vec!["determine".to_string(), "predetermine".to_string()]
+        )
+    }
+
+    #[test]
+    fn test_expand_regex_aborted_case() {
+        let result = expand_regex("[^Aa]pple").unwrap();
+        assert_eq!(result, Vec::<String>::new());
+
+        let result = expand_regex("a[^Aa]pple").unwrap();
+        assert_eq!(result, Vec::<String>::new());
+    }
+}


### PR DESCRIPTION
Add a module for expanding regex patterns into concrete strings, so that exceptions defined as regexes can be expanded into concrete suggestions.