### PR TITLE
fix(interactive mode): skipping errors

### DIFF
--- a/src/cli/interactive.rs
+++ b/src/cli/interactive.rs
@@ -121,7 +121,7 @@ impl<'a, 'b> InteractiveFixManager<'a, 'b> {
     }
 
     pub fn run_relint_loop(&mut self) -> Result<()> {
-        loop {
+        'relint: loop {
             let diagnostics = self.linter.lint(&LintTarget::String(
                 &self.curr_file.as_ref().unwrap().content.as_str(),
             ))?;
@@ -142,7 +142,7 @@ impl<'a, 'b> InteractiveFixManager<'a, 'b> {
                         if let Some(CorrectionStrategy::Fix) =
                             self.prompt_error().error(error).call()?
                         {
-                            break;
+                            continue 'relint;
                         }
                     }
                     return Ok(());


### PR DESCRIPTION
Messed up the relint loop when I refactored, which caused subsequent errors to be skipped when an error was fixed in a file.