### PR TITLE
fix: spawning editor in Node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -190,6 +190,114 @@
       "resolved": "packages/supa-mdx-lint",
       "link": true
     },
+    "node_modules/@supabase/supa-mdx-lint-darwin": {
+      "version": "0.2.4-alpha",
+      "resolved": "https://registry.npmjs.org/@supabase/supa-mdx-lint-darwin/-/supa-mdx-lint-darwin-0.2.4-alpha.tgz",
+      "integrity": "sha512-8Yaq6XZpGLpU5vHQIhspWST69HjKO0v3U3VmobNN4jDcW/Z1O2gzngulIixkHV+MatmSP2pP+fg1GKjQOsyxpg==",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@supabase/supa-mdx-lint-linux-arm": {
+      "version": "0.2.4-alpha",
+      "resolved": "https://registry.npmjs.org/@supabase/supa-mdx-lint-linux-arm/-/supa-mdx-lint-linux-arm-0.2.4-alpha.tgz",
+      "integrity": "sha512-Afw0vCg0/5hn8obJ6oY49W+k9JNaILETQKMYNiP5K3lIQxwUCTCMJYb8KIjWkJcUmc7JJlzaPhFuH0cvcROJAg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@supabase/supa-mdx-lint-linux-arm64": {
+      "version": "0.2.4-alpha",
+      "resolved": "https://registry.npmjs.org/@supabase/supa-mdx-lint-linux-arm64/-/supa-mdx-lint-linux-arm64-0.2.4-alpha.tgz",
+      "integrity": "sha512-dFy0MRySDMgbgx5i0tXxg+06UTh1LBBtxoY/4TTbGeu9ntk4JIed+Ckf92sUAxw0gyZU7lsQ7MhoBNhHirIavQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@supabase/supa-mdx-lint-linux-i686": {
+      "version": "0.2.4-alpha",
+      "resolved": "https://registry.npmjs.org/@supabase/supa-mdx-lint-linux-i686/-/supa-mdx-lint-linux-i686-0.2.4-alpha.tgz",
+      "integrity": "sha512-/fPv/UuS0T9Iyc7Z9Bt0/tXo6v4WqIwPObUbMOM57q8TUQbzJW+Mm/HMH8l+OLBcwYLjz5+ElfJXhGXCMV5qHw==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@supabase/supa-mdx-lint-linux-x64": {
+      "version": "0.2.4-alpha",
+      "resolved": "https://registry.npmjs.org/@supabase/supa-mdx-lint-linux-x64/-/supa-mdx-lint-linux-x64-0.2.4-alpha.tgz",
+      "integrity": "sha512-VEoyxDSowFA5xlBEwyNHd4pRuFwH1qI7gRkO9cGt3NM/bWcbRE/3+RfP4BRyfsRB/Mzlx0RXGqVKS3P2xgUJ0g==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@supabase/supa-mdx-lint-win32-i686": {
+      "version": "0.2.4-alpha",
+      "resolved": "https://registry.npmjs.org/@supabase/supa-mdx-lint-win32-i686/-/supa-mdx-lint-win32-i686-0.2.4-alpha.tgz",
+      "integrity": "sha512-UMLVpXkxiEGcZUXhq8wbbn2b9F2I3MC9zm3DGm43kSywOrgv3/mNT88rJJIxn2+NoROGpN23GCICibSYf/ZzZQ==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@supabase/supa-mdx-lint-win32-x64": {
+      "version": "0.2.4-alpha",
+      "resolved": "https://registry.npmjs.org/@supabase/supa-mdx-lint-win32-x64/-/supa-mdx-lint-win32-x64-0.2.4-alpha.tgz",
+      "integrity": "sha512-XhYVVHo1R7fKBZcJVIp/Zd1uzkj/QSeJxEQVlJUr5zQrQXyIKp99EbcMeqUbAmbdzFttCGfw28KA4JFP+BvPig==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -773,10 +881,24 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
+    "node_modules/nan": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
+      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw=="
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
+    },
+    "node_modules/node-pty": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.0.0.tgz",
+      "integrity": "sha512-wtBMWWS7dFZm/VgqElrTvtfMq4GzJ6+edFI0Y0zyzygUSZMgZdraDUMUhCIvkjhJjme15qWmbyJbtAx4ot4uZA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "nan": "^2.17.0"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -1049,7 +1171,10 @@
     },
     "packages/supa-mdx-lint": {
       "name": "@supabase/supa-mdx-lint",
-      "version": "0.2.0-alpha",
+      "version": "0.2.4-alpha",
+      "dependencies": {
+        "node-pty": "^1.0.0"
+      },
       "bin": {
         "supa-mdx-lint": "src/index.js"
       },
@@ -1060,13 +1185,13 @@
         "prettier": "^3.3.3"
       },
       "optionalDependencies": {
-        "@supabase/supa-mdx-lint-darwin": "0.2.0-alpha",
-        "@supabase/supa-mdx-lint-linux-arm": "0.2.0-alpha",
-        "@supabase/supa-mdx-lint-linux-arm64": "0.2.0-alpha",
-        "@supabase/supa-mdx-lint-linux-i686": "0.2.0-alpha",
-        "@supabase/supa-mdx-lint-linux-x64": "0.2.0-alpha",
-        "@supabase/supa-mdx-lint-win32-i686": "0.2.0-alpha",
-        "@supabase/supa-mdx-lint-win32-x64": "0.2.0-alpha"
+        "@supabase/supa-mdx-lint-darwin": "0.2.4-alpha",
+        "@supabase/supa-mdx-lint-linux-arm": "0.2.4-alpha",
+        "@supabase/supa-mdx-lint-linux-arm64": "0.2.4-alpha",
+        "@supabase/supa-mdx-lint-linux-i686": "0.2.4-alpha",
+        "@supabase/supa-mdx-lint-linux-x64": "0.2.4-alpha",
+        "@supabase/supa-mdx-lint-win32-i686": "0.2.4-alpha",
+        "@supabase/supa-mdx-lint-win32-x64": "0.2.4-alpha"
       }
     }
   }

--- a/packages/supa-mdx-lint/package.json
+++ b/packages/supa-mdx-lint/package.json
@@ -28,5 +28,8 @@
     "@supabase/supa-mdx-lint-linux-x64": "0.2.4-alpha",
     "@supabase/supa-mdx-lint-win32-i686": "0.2.4-alpha",
     "@supabase/supa-mdx-lint-win32-x64": "0.2.4-alpha"
+  },
+  "dependencies": {
+    "node-pty": "^1.0.0"
   }
 }

--- a/packages/supa-mdx-lint/src/index.js
+++ b/packages/supa-mdx-lint/src/index.js
@@ -10,6 +10,7 @@ async function main() {
   const args = process.argv.slice(2);
   try {
     await helper.execute(args);
+    process.exit(0);
   } catch (err) {
     process.exit(err.code ?? 1);
   }


### PR DESCRIPTION
The Node wrapper runs the binary in a child process, which is not a terminal. This causes problems with Vim, which is expecting to be run from within a terminal.

Instead, use node-pty to get a pseudo-terminal.