### PR TITLE
fix: fix test errors

### DIFF
--- a/packages/supa-mdx-lint/package.json
+++ b/packages/supa-mdx-lint/package.json
@@ -27,9 +27,7 @@
     "@supabase/supa-mdx-lint-linux-i686": "0.2.5-alpha",
     "@supabase/supa-mdx-lint-linux-x64": "0.2.5-alpha",
     "@supabase/supa-mdx-lint-win32-i686": "0.2.5-alpha",
-    "@supabase/supa-mdx-lint-win32-x64": "0.2.5-alpha"
-  },
-  "dependencies": {
+    "@supabase/supa-mdx-lint-win32-x64": "0.2.5-alpha",
     "node-pty": "^1.0.0"
   }
 }

--- a/packages/supa-mdx-lint/src/helper.js
+++ b/packages/supa-mdx-lint/src/helper.js
@@ -200,7 +200,13 @@ async function execute(args) {
       }
     });
 
-    process.stdin.setRawMode(true);
+    if (process.stdin.isTTY) {
+      process.stdin.setRawMode(true);
+    } else {
+      console.warn(
+        "Warning: process.stdin is not a TTY. setRawMode is not available.",
+      );
+    }
     process.stdin.setEncoding("utf8");
 
     process.stdin.on("data", (data) => {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -117,7 +117,7 @@ fn parse_internal(input: &str) -> Result<Node> {
             ..Default::default()
         },
     )
-    .map_err(|e| anyhow!("Markdown parsing error: {:?}", e))?;
+    .map_err(|e| anyhow!("Not valid Markdown: {:?}", e))?;
 
     Ok(mdast)
 }


### PR DESCRIPTION
Tests are broken because CI tests are not run in a TTY, therefore setting raw mode for process.stdin (needed for the pseudo-TTY) isn't possible. Tests only run the version command, which doesn't need the pseudo-TTY functionality, so just bypass it with a warning.

node-pty doesn't work on the combination of windows + node 22 (something to do with node-gyp build breaking). Since it's needed only for pass-through of the experimental interactive fix feature, let's fall back to child_process.spawn on Windows (and deliberately break interactive fix mode)