### PR TITLE
chore: clean up public api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
+name = "camino"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-manifest"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2ce2075c35e4b492b93e3d5dd1dd3670de553f15045595daef8164ed9a3751"
+dependencies = [
+ "serde",
+ "thiserror 1.0.69",
+ "toml",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,6 +553,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "hashbag"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98f494b2060b2a8f5e63379e1e487258e014cee1b1725a735816c0107a2e9d93"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -544,6 +593,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50259abbaa67d11d2bcafc7ba1d094ed7a0c70e3ce893f0d0997f73558cb3084"
+dependencies = [
+ "console",
+ "linked-hash-map",
+ "once_cell",
+ "pin-project",
+ "similar",
+]
+
+[[package]]
 name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,6 +637,12 @@ name = "libc"
 version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -695,6 +763,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56"
 
 [[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,6 +844,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "public-api"
+version = "0.44.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b782050f709c24580467137c5908b1474756b8543c45e464332dc561ffbe65"
+dependencies = [
+ "hashbag",
+ "rustdoc-types",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.4",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,6 +901,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustdoc-json"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e27b4d503f72ab0feb20d2b4968930f21ebf1fc904f8792329f4176f02a65d6"
+dependencies = [
+ "cargo-manifest",
+ "cargo_metadata",
+ "serde",
+ "thiserror 2.0.4",
+ "toml",
+ "tracing",
+]
+
+[[package]]
+name = "rustdoc-types"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf583db9958b3161d7980a56a8ee3c25e1a40708b81259be72584b7e0ea07c95"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,6 +937,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustup-toolchain"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5715001c3f29532641421aaddb1302cbcbfd7507ed5f3a5dd0ddb5b808a7e0"
+dependencies = [
+ "thiserror 2.0.4",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,6 +956,15 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"
@@ -879,6 +1027,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "simplelog"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -925,14 +1079,18 @@ dependencies = [
  "gag",
  "glob",
  "indexmap",
+ "insta",
  "itertools",
  "log",
  "markdown",
  "miette",
  "owo-colors",
  "predicates",
+ "public-api",
  "regex",
  "regex-syntax",
+ "rustdoc-json",
+ "rustup-toolchain",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1132,10 +1290,11 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -1153,15 +1312,46 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
  "winnow",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
@@ -1402,9 +1592,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,11 @@ toml = "0.8.19"
 assert_cmd = "2.0.16"
 ctor = "0.2.8"
 env_logger = "0.11.5"
+insta = "1.42.2"
 predicates = "3.1.2"
+public-api = "0.44.2"
+rustdoc-json = "0.9.5"
+rustup-toolchain = "0.1.10"
 tempfile = "3.13.0"
 
 [features]

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,7 +16,17 @@ use crate::{
 const IGNORE_GLOBS_KEY: &str = "ignore_patterns";
 
 #[derive(Debug, Clone)]
-pub struct ConfigDir(pub Option<PathBuf>);
+pub struct ConfigDir(Option<PathBuf>);
+
+impl ConfigDir {
+    pub fn none() -> Self {
+        Self(None)
+    }
+
+    pub fn new(path: PathBuf) -> Self {
+        Self(Some(path))
+    }
+}
 
 #[derive(Debug)]
 pub struct Config {
@@ -211,7 +221,13 @@ impl Config {
         Ok((registry, rule_specific_settings, ignore_globs))
     }
 
-    pub fn is_ignored(&self, path: &Path) -> bool {
+    pub(crate) fn is_lintable(&self, path: impl AsRef<Path>) -> bool {
+        let path = path.as_ref();
+        path.is_dir() || path.extension().map_or(false, |ext| ext == "mdx")
+    }
+
+    pub(crate) fn is_ignored(&self, path: impl AsRef<Path>) -> bool {
+        let path = path.as_ref();
         let path = if path.is_relative() {
             let current_dir = env::current_dir().unwrap();
             &current_dir.join(path)

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -9,7 +9,7 @@ use crate::{
     context::Context,
     fix::LintCorrection,
     geometry::{AdjustedPoint, AdjustedRange, DenormalizedLocation},
-    utils::Offsets,
+    internal::Offsets,
 };
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]

--- a/src/fix.rs
+++ b/src/fix.rs
@@ -9,12 +9,10 @@ use crate::{
     app_error::AppError,
     context::Context,
     geometry::{AdjustedRange, DenormalizedLocation},
+    internal::Offsets,
     output::LintOutput,
     rope::Rope,
-    utils::{
-        words::{is_sentence_start, WordIterator},
-        Offsets,
-    },
+    utils::words::{is_sentence_start, WordIterator},
     Linter,
 };
 
@@ -37,6 +35,16 @@ pub struct LintCorrectionDelete {
     pub(crate) location: DenormalizedLocation,
 }
 
+impl Offsets for LintCorrectionDelete {
+    fn start(&self) -> usize {
+        self.location.offset_range.start.into()
+    }
+
+    fn end(&self) -> usize {
+        self.location.offset_range.end.into()
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct LintCorrectionReplace {
     pub(crate) location: DenormalizedLocation,
@@ -56,16 +64,6 @@ impl Offsets for LintCorrectionInsert {
 impl LintCorrectionInsert {
     pub fn text(&self) -> &str {
         &self.text
-    }
-}
-
-impl Offsets for LintCorrectionDelete {
-    fn start(&self) -> usize {
-        self.location.offset_range.start.into()
-    }
-
-    fn end(&self) -> usize {
-        self.location.offset_range.end.into()
     }
 }
 

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -374,6 +374,21 @@ impl RangeSet {
     }
 }
 
+pub trait Offsets {
+    fn start(&self) -> usize;
+    fn end(&self) -> usize;
+}
+
+impl<T: Offsets> Offsets for &T {
+    fn start(&self) -> usize {
+        (*self).start()
+    }
+
+    fn end(&self) -> usize {
+        (*self).end()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{AdjustedOffset, AdjustedPoint, AdjustedRange, DenormalizedLocation};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,6 +169,26 @@ mod tests {
     }
 
     #[test]
+    fn public_api() {
+        // Install a compatible nightly toolchain if it is missing
+        rustup_toolchain::install(public_api::MINIMUM_NIGHTLY_RUST_VERSION).unwrap();
+
+        // Build rustdoc JSON
+        let rustdoc_json = rustdoc_json::Builder::default()
+            .toolchain(public_api::MINIMUM_NIGHTLY_RUST_VERSION)
+            .build()
+            .unwrap();
+
+        // Derive the public API from the rustdoc JSON
+        let public_api = public_api::Builder::from_rustdoc_json(rustdoc_json)
+            .build()
+            .unwrap();
+
+        // Assert that the public API looks correct
+        insta::assert_snapshot!(public_api);
+    }
+
+    #[test]
     fn test_lint_valid_string() -> Result<()> {
         let mut linter = Linter::builder().build()?;
         linter

--- a/src/output.rs
+++ b/src/output.rs
@@ -17,7 +17,7 @@ pub struct LintOutput {
 }
 
 impl LintOutput {
-    pub fn new(file_path: impl AsRef<str>, errors: Vec<LintError>) -> Self {
+    pub(crate) fn new(file_path: impl AsRef<str>, errors: Vec<LintError>) -> Self {
         Self {
             file_path: file_path.as_ref().to_string(),
             errors,
@@ -34,9 +34,9 @@ impl LintOutput {
 }
 
 pub struct OutputSummary {
-    num_files: usize,
-    num_warnings: usize,
-    num_errors: usize,
+    pub num_files: usize,
+    pub num_warnings: usize,
+    pub num_errors: usize,
 }
 
 pub trait OutputFormatter: Send + Sync + std::fmt::Debug {
@@ -68,7 +68,7 @@ pub trait OutputFormatter: Send + Sync + std::fmt::Debug {
 }
 
 #[doc(hidden)]
-pub(crate) mod internal {
+pub mod internal {
     //! Contains internal implementations that are needed for the supa-mdx-lint
     //! binary. Should **not** be used by library users as API stability is
     //! not guaranteed.

--- a/src/snapshots/supa_mdx_lint__tests__public_api.snap
+++ b/src/snapshots/supa_mdx_lint__tests__public_api.snap
@@ -1,0 +1,790 @@
+---
+source: src/lib.rs
+expression: public_api
+---
+pub mod supa_mdx_lint
+pub mod supa_mdx_lint::fix
+pub enum supa_mdx_lint::fix::LintCorrection
+pub supa_mdx_lint::fix::LintCorrection::Delete(supa_mdx_lint::fix::LintCorrectionDelete)
+pub supa_mdx_lint::fix::LintCorrection::Insert(supa_mdx_lint::fix::LintCorrectionInsert)
+pub supa_mdx_lint::fix::LintCorrection::Replace(supa_mdx_lint::fix::LintCorrectionReplace)
+impl core::clone::Clone for supa_mdx_lint::fix::LintCorrection
+pub fn supa_mdx_lint::fix::LintCorrection::clone(&self) -> supa_mdx_lint::fix::LintCorrection
+impl core::cmp::Eq for supa_mdx_lint::fix::LintCorrection
+impl core::cmp::Ord for supa_mdx_lint::fix::LintCorrection
+pub fn supa_mdx_lint::fix::LintCorrection::cmp(&self, other: &Self) -> core::cmp::Ordering
+impl core::cmp::PartialEq for supa_mdx_lint::fix::LintCorrection
+pub fn supa_mdx_lint::fix::LintCorrection::eq(&self, other: &supa_mdx_lint::fix::LintCorrection) -> bool
+impl core::cmp::PartialOrd for supa_mdx_lint::fix::LintCorrection
+pub fn supa_mdx_lint::fix::LintCorrection::partial_cmp(&self, other: &Self) -> core::option::Option<core::cmp::Ordering>
+impl core::fmt::Debug for supa_mdx_lint::fix::LintCorrection
+pub fn supa_mdx_lint::fix::LintCorrection::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for supa_mdx_lint::fix::LintCorrection
+impl serde::ser::Serialize for supa_mdx_lint::fix::LintCorrection
+pub fn supa_mdx_lint::fix::LintCorrection::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for supa_mdx_lint::fix::LintCorrection
+pub fn supa_mdx_lint::fix::LintCorrection::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Freeze for supa_mdx_lint::fix::LintCorrection
+impl core::marker::Send for supa_mdx_lint::fix::LintCorrection
+impl core::marker::Sync for supa_mdx_lint::fix::LintCorrection
+impl core::marker::Unpin for supa_mdx_lint::fix::LintCorrection
+impl core::panic::unwind_safe::RefUnwindSafe for supa_mdx_lint::fix::LintCorrection
+impl core::panic::unwind_safe::UnwindSafe for supa_mdx_lint::fix::LintCorrection
+impl<Q, K> equivalent::Comparable<K> for supa_mdx_lint::fix::LintCorrection where Q: core::cmp::Ord + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn supa_mdx_lint::fix::LintCorrection::compare(&self, key: &K) -> core::cmp::Ordering
+impl<Q, K> equivalent::Equivalent<K> for supa_mdx_lint::fix::LintCorrection where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn supa_mdx_lint::fix::LintCorrection::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for supa_mdx_lint::fix::LintCorrection where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn supa_mdx_lint::fix::LintCorrection::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for supa_mdx_lint::fix::LintCorrection where U: core::convert::From<T>
+pub fn supa_mdx_lint::fix::LintCorrection::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for supa_mdx_lint::fix::LintCorrection where U: core::convert::Into<T>
+pub type supa_mdx_lint::fix::LintCorrection::Error = core::convert::Infallible
+pub fn supa_mdx_lint::fix::LintCorrection::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for supa_mdx_lint::fix::LintCorrection where U: core::convert::TryFrom<T>
+pub type supa_mdx_lint::fix::LintCorrection::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn supa_mdx_lint::fix::LintCorrection::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for supa_mdx_lint::fix::LintCorrection where T: core::clone::Clone
+pub type supa_mdx_lint::fix::LintCorrection::Owned = T
+pub fn supa_mdx_lint::fix::LintCorrection::clone_into(&self, target: &mut T)
+pub fn supa_mdx_lint::fix::LintCorrection::to_owned(&self) -> T
+impl<T> core::any::Any for supa_mdx_lint::fix::LintCorrection where T: 'static + ?core::marker::Sized
+pub fn supa_mdx_lint::fix::LintCorrection::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for supa_mdx_lint::fix::LintCorrection where T: ?core::marker::Sized
+pub fn supa_mdx_lint::fix::LintCorrection::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for supa_mdx_lint::fix::LintCorrection where T: ?core::marker::Sized
+pub fn supa_mdx_lint::fix::LintCorrection::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for supa_mdx_lint::fix::LintCorrection where T: core::clone::Clone
+pub unsafe fn supa_mdx_lint::fix::LintCorrection::clone_to_uninit(&self, dst: *mut u8)
+impl<T> core::convert::From<T> for supa_mdx_lint::fix::LintCorrection
+pub fn supa_mdx_lint::fix::LintCorrection::from(t: T) -> T
+impl<T> either::into_either::IntoEither for supa_mdx_lint::fix::LintCorrection
+impl<T> serde::de::DeserializeOwned for supa_mdx_lint::fix::LintCorrection where T: for<'de> serde::de::Deserialize<'de>
+pub struct supa_mdx_lint::fix::LintCorrectionDelete
+impl core::clone::Clone for supa_mdx_lint::fix::LintCorrectionDelete
+pub fn supa_mdx_lint::fix::LintCorrectionDelete::clone(&self) -> supa_mdx_lint::fix::LintCorrectionDelete
+impl core::cmp::Eq for supa_mdx_lint::fix::LintCorrectionDelete
+impl core::cmp::PartialEq for supa_mdx_lint::fix::LintCorrectionDelete
+pub fn supa_mdx_lint::fix::LintCorrectionDelete::eq(&self, other: &supa_mdx_lint::fix::LintCorrectionDelete) -> bool
+impl core::fmt::Debug for supa_mdx_lint::fix::LintCorrectionDelete
+pub fn supa_mdx_lint::fix::LintCorrectionDelete::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for supa_mdx_lint::fix::LintCorrectionDelete
+impl serde::ser::Serialize for supa_mdx_lint::fix::LintCorrectionDelete
+pub fn supa_mdx_lint::fix::LintCorrectionDelete::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl supa_mdx_lint::geometry::Offsets for supa_mdx_lint::fix::LintCorrectionDelete
+pub fn supa_mdx_lint::fix::LintCorrectionDelete::end(&self) -> usize
+pub fn supa_mdx_lint::fix::LintCorrectionDelete::start(&self) -> usize
+impl<'de> serde::de::Deserialize<'de> for supa_mdx_lint::fix::LintCorrectionDelete
+pub fn supa_mdx_lint::fix::LintCorrectionDelete::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Freeze for supa_mdx_lint::fix::LintCorrectionDelete
+impl core::marker::Send for supa_mdx_lint::fix::LintCorrectionDelete
+impl core::marker::Sync for supa_mdx_lint::fix::LintCorrectionDelete
+impl core::marker::Unpin for supa_mdx_lint::fix::LintCorrectionDelete
+impl core::panic::unwind_safe::RefUnwindSafe for supa_mdx_lint::fix::LintCorrectionDelete
+impl core::panic::unwind_safe::UnwindSafe for supa_mdx_lint::fix::LintCorrectionDelete
+impl<Q, K> equivalent::Equivalent<K> for supa_mdx_lint::fix::LintCorrectionDelete where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn supa_mdx_lint::fix::LintCorrectionDelete::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for supa_mdx_lint::fix::LintCorrectionDelete where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn supa_mdx_lint::fix::LintCorrectionDelete::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for supa_mdx_lint::fix::LintCorrectionDelete where U: core::convert::From<T>
+pub fn supa_mdx_lint::fix::LintCorrectionDelete::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for supa_mdx_lint::fix::LintCorrectionDelete where U: core::convert::Into<T>
+pub type supa_mdx_lint::fix::LintCorrectionDelete::Error = core::convert::Infallible
+pub fn supa_mdx_lint::fix::LintCorrectionDelete::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for supa_mdx_lint::fix::LintCorrectionDelete where U: core::convert::TryFrom<T>
+pub type supa_mdx_lint::fix::LintCorrectionDelete::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn supa_mdx_lint::fix::LintCorrectionDelete::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for supa_mdx_lint::fix::LintCorrectionDelete where T: core::clone::Clone
+pub type supa_mdx_lint::fix::LintCorrectionDelete::Owned = T
+pub fn supa_mdx_lint::fix::LintCorrectionDelete::clone_into(&self, target: &mut T)
+pub fn supa_mdx_lint::fix::LintCorrectionDelete::to_owned(&self) -> T
+impl<T> core::any::Any for supa_mdx_lint::fix::LintCorrectionDelete where T: 'static + ?core::marker::Sized
+pub fn supa_mdx_lint::fix::LintCorrectionDelete::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for supa_mdx_lint::fix::LintCorrectionDelete where T: ?core::marker::Sized
+pub fn supa_mdx_lint::fix::LintCorrectionDelete::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for supa_mdx_lint::fix::LintCorrectionDelete where T: ?core::marker::Sized
+pub fn supa_mdx_lint::fix::LintCorrectionDelete::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for supa_mdx_lint::fix::LintCorrectionDelete where T: core::clone::Clone
+pub unsafe fn supa_mdx_lint::fix::LintCorrectionDelete::clone_to_uninit(&self, dst: *mut u8)
+impl<T> core::convert::From<T> for supa_mdx_lint::fix::LintCorrectionDelete
+pub fn supa_mdx_lint::fix::LintCorrectionDelete::from(t: T) -> T
+impl<T> either::into_either::IntoEither for supa_mdx_lint::fix::LintCorrectionDelete
+impl<T> serde::de::DeserializeOwned for supa_mdx_lint::fix::LintCorrectionDelete where T: for<'de> serde::de::Deserialize<'de>
+pub struct supa_mdx_lint::fix::LintCorrectionInsert
+impl supa_mdx_lint::fix::LintCorrectionInsert
+pub fn supa_mdx_lint::fix::LintCorrectionInsert::text(&self) -> &str
+impl core::clone::Clone for supa_mdx_lint::fix::LintCorrectionInsert
+pub fn supa_mdx_lint::fix::LintCorrectionInsert::clone(&self) -> supa_mdx_lint::fix::LintCorrectionInsert
+impl core::cmp::Eq for supa_mdx_lint::fix::LintCorrectionInsert
+impl core::cmp::PartialEq for supa_mdx_lint::fix::LintCorrectionInsert
+pub fn supa_mdx_lint::fix::LintCorrectionInsert::eq(&self, other: &supa_mdx_lint::fix::LintCorrectionInsert) -> bool
+impl core::fmt::Debug for supa_mdx_lint::fix::LintCorrectionInsert
+pub fn supa_mdx_lint::fix::LintCorrectionInsert::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for supa_mdx_lint::fix::LintCorrectionInsert
+impl serde::ser::Serialize for supa_mdx_lint::fix::LintCorrectionInsert
+pub fn supa_mdx_lint::fix::LintCorrectionInsert::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl supa_mdx_lint::geometry::Offsets for supa_mdx_lint::fix::LintCorrectionInsert
+pub fn supa_mdx_lint::fix::LintCorrectionInsert::end(&self) -> usize
+pub fn supa_mdx_lint::fix::LintCorrectionInsert::start(&self) -> usize
+impl<'de> serde::de::Deserialize<'de> for supa_mdx_lint::fix::LintCorrectionInsert
+pub fn supa_mdx_lint::fix::LintCorrectionInsert::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Freeze for supa_mdx_lint::fix::LintCorrectionInsert
+impl core::marker::Send for supa_mdx_lint::fix::LintCorrectionInsert
+impl core::marker::Sync for supa_mdx_lint::fix::LintCorrectionInsert
+impl core::marker::Unpin for supa_mdx_lint::fix::LintCorrectionInsert
+impl core::panic::unwind_safe::RefUnwindSafe for supa_mdx_lint::fix::LintCorrectionInsert
+impl core::panic::unwind_safe::UnwindSafe for supa_mdx_lint::fix::LintCorrectionInsert
+impl<Q, K> equivalent::Equivalent<K> for supa_mdx_lint::fix::LintCorrectionInsert where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn supa_mdx_lint::fix::LintCorrectionInsert::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for supa_mdx_lint::fix::LintCorrectionInsert where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn supa_mdx_lint::fix::LintCorrectionInsert::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for supa_mdx_lint::fix::LintCorrectionInsert where U: core::convert::From<T>
+pub fn supa_mdx_lint::fix::LintCorrectionInsert::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for supa_mdx_lint::fix::LintCorrectionInsert where U: core::convert::Into<T>
+pub type supa_mdx_lint::fix::LintCorrectionInsert::Error = core::convert::Infallible
+pub fn supa_mdx_lint::fix::LintCorrectionInsert::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for supa_mdx_lint::fix::LintCorrectionInsert where U: core::convert::TryFrom<T>
+pub type supa_mdx_lint::fix::LintCorrectionInsert::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn supa_mdx_lint::fix::LintCorrectionInsert::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for supa_mdx_lint::fix::LintCorrectionInsert where T: core::clone::Clone
+pub type supa_mdx_lint::fix::LintCorrectionInsert::Owned = T
+pub fn supa_mdx_lint::fix::LintCorrectionInsert::clone_into(&self, target: &mut T)
+pub fn supa_mdx_lint::fix::LintCorrectionInsert::to_owned(&self) -> T
+impl<T> core::any::Any for supa_mdx_lint::fix::LintCorrectionInsert where T: 'static + ?core::marker::Sized
+pub fn supa_mdx_lint::fix::LintCorrectionInsert::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for supa_mdx_lint::fix::LintCorrectionInsert where T: ?core::marker::Sized
+pub fn supa_mdx_lint::fix::LintCorrectionInsert::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for supa_mdx_lint::fix::LintCorrectionInsert where T: ?core::marker::Sized
+pub fn supa_mdx_lint::fix::LintCorrectionInsert::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for supa_mdx_lint::fix::LintCorrectionInsert where T: core::clone::Clone
+pub unsafe fn supa_mdx_lint::fix::LintCorrectionInsert::clone_to_uninit(&self, dst: *mut u8)
+impl<T> core::convert::From<T> for supa_mdx_lint::fix::LintCorrectionInsert
+pub fn supa_mdx_lint::fix::LintCorrectionInsert::from(t: T) -> T
+impl<T> either::into_either::IntoEither for supa_mdx_lint::fix::LintCorrectionInsert
+impl<T> serde::de::DeserializeOwned for supa_mdx_lint::fix::LintCorrectionInsert where T: for<'de> serde::de::Deserialize<'de>
+pub struct supa_mdx_lint::fix::LintCorrectionReplace
+impl supa_mdx_lint::fix::LintCorrectionReplace
+pub fn supa_mdx_lint::fix::LintCorrectionReplace::text(&self) -> &str
+impl core::clone::Clone for supa_mdx_lint::fix::LintCorrectionReplace
+pub fn supa_mdx_lint::fix::LintCorrectionReplace::clone(&self) -> supa_mdx_lint::fix::LintCorrectionReplace
+impl core::cmp::Eq for supa_mdx_lint::fix::LintCorrectionReplace
+impl core::cmp::PartialEq for supa_mdx_lint::fix::LintCorrectionReplace
+pub fn supa_mdx_lint::fix::LintCorrectionReplace::eq(&self, other: &supa_mdx_lint::fix::LintCorrectionReplace) -> bool
+impl core::fmt::Debug for supa_mdx_lint::fix::LintCorrectionReplace
+pub fn supa_mdx_lint::fix::LintCorrectionReplace::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for supa_mdx_lint::fix::LintCorrectionReplace
+impl serde::ser::Serialize for supa_mdx_lint::fix::LintCorrectionReplace
+pub fn supa_mdx_lint::fix::LintCorrectionReplace::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl supa_mdx_lint::geometry::Offsets for supa_mdx_lint::fix::LintCorrectionReplace
+pub fn supa_mdx_lint::fix::LintCorrectionReplace::end(&self) -> usize
+pub fn supa_mdx_lint::fix::LintCorrectionReplace::start(&self) -> usize
+impl<'de> serde::de::Deserialize<'de> for supa_mdx_lint::fix::LintCorrectionReplace
+pub fn supa_mdx_lint::fix::LintCorrectionReplace::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Freeze for supa_mdx_lint::fix::LintCorrectionReplace
+impl core::marker::Send for supa_mdx_lint::fix::LintCorrectionReplace
+impl core::marker::Sync for supa_mdx_lint::fix::LintCorrectionReplace
+impl core::marker::Unpin for supa_mdx_lint::fix::LintCorrectionReplace
+impl core::panic::unwind_safe::RefUnwindSafe for supa_mdx_lint::fix::LintCorrectionReplace
+impl core::panic::unwind_safe::UnwindSafe for supa_mdx_lint::fix::LintCorrectionReplace
+impl<Q, K> equivalent::Equivalent<K> for supa_mdx_lint::fix::LintCorrectionReplace where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn supa_mdx_lint::fix::LintCorrectionReplace::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for supa_mdx_lint::fix::LintCorrectionReplace where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn supa_mdx_lint::fix::LintCorrectionReplace::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for supa_mdx_lint::fix::LintCorrectionReplace where U: core::convert::From<T>
+pub fn supa_mdx_lint::fix::LintCorrectionReplace::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for supa_mdx_lint::fix::LintCorrectionReplace where U: core::convert::Into<T>
+pub type supa_mdx_lint::fix::LintCorrectionReplace::Error = core::convert::Infallible
+pub fn supa_mdx_lint::fix::LintCorrectionReplace::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for supa_mdx_lint::fix::LintCorrectionReplace where U: core::convert::TryFrom<T>
+pub type supa_mdx_lint::fix::LintCorrectionReplace::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn supa_mdx_lint::fix::LintCorrectionReplace::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for supa_mdx_lint::fix::LintCorrectionReplace where T: core::clone::Clone
+pub type supa_mdx_lint::fix::LintCorrectionReplace::Owned = T
+pub fn supa_mdx_lint::fix::LintCorrectionReplace::clone_into(&self, target: &mut T)
+pub fn supa_mdx_lint::fix::LintCorrectionReplace::to_owned(&self) -> T
+impl<T> core::any::Any for supa_mdx_lint::fix::LintCorrectionReplace where T: 'static + ?core::marker::Sized
+pub fn supa_mdx_lint::fix::LintCorrectionReplace::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for supa_mdx_lint::fix::LintCorrectionReplace where T: ?core::marker::Sized
+pub fn supa_mdx_lint::fix::LintCorrectionReplace::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for supa_mdx_lint::fix::LintCorrectionReplace where T: ?core::marker::Sized
+pub fn supa_mdx_lint::fix::LintCorrectionReplace::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for supa_mdx_lint::fix::LintCorrectionReplace where T: core::clone::Clone
+pub unsafe fn supa_mdx_lint::fix::LintCorrectionReplace::clone_to_uninit(&self, dst: *mut u8)
+impl<T> core::convert::From<T> for supa_mdx_lint::fix::LintCorrectionReplace
+pub fn supa_mdx_lint::fix::LintCorrectionReplace::from(t: T) -> T
+impl<T> either::into_either::IntoEither for supa_mdx_lint::fix::LintCorrectionReplace
+impl<T> serde::de::DeserializeOwned for supa_mdx_lint::fix::LintCorrectionReplace where T: for<'de> serde::de::Deserialize<'de>
+pub mod supa_mdx_lint::output
+pub mod supa_mdx_lint::output::markdown
+pub struct supa_mdx_lint::output::markdown::MarkdownFormatter
+impl core::clone::Clone for supa_mdx_lint::output::markdown::MarkdownFormatter
+pub fn supa_mdx_lint::output::markdown::MarkdownFormatter::clone(&self) -> supa_mdx_lint::output::markdown::MarkdownFormatter
+impl core::fmt::Debug for supa_mdx_lint::output::markdown::MarkdownFormatter
+pub fn supa_mdx_lint::output::markdown::MarkdownFormatter::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl supa_mdx_lint::output::OutputFormatter for supa_mdx_lint::output::markdown::MarkdownFormatter
+pub fn supa_mdx_lint::output::markdown::MarkdownFormatter::format(&self, output: &[supa_mdx_lint::output::LintOutput]) -> anyhow::Result<alloc::string::String>
+pub fn supa_mdx_lint::output::markdown::MarkdownFormatter::id(&self) -> &'static str
+pub fn supa_mdx_lint::output::markdown::MarkdownFormatter::should_log_metadata(&self) -> bool
+impl core::marker::Freeze for supa_mdx_lint::output::markdown::MarkdownFormatter
+impl core::marker::Send for supa_mdx_lint::output::markdown::MarkdownFormatter
+impl core::marker::Sync for supa_mdx_lint::output::markdown::MarkdownFormatter
+impl core::marker::Unpin for supa_mdx_lint::output::markdown::MarkdownFormatter
+impl core::panic::unwind_safe::RefUnwindSafe for supa_mdx_lint::output::markdown::MarkdownFormatter
+impl core::panic::unwind_safe::UnwindSafe for supa_mdx_lint::output::markdown::MarkdownFormatter
+impl<T, U> core::convert::Into<U> for supa_mdx_lint::output::markdown::MarkdownFormatter where U: core::convert::From<T>
+pub fn supa_mdx_lint::output::markdown::MarkdownFormatter::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for supa_mdx_lint::output::markdown::MarkdownFormatter where U: core::convert::Into<T>
+pub type supa_mdx_lint::output::markdown::MarkdownFormatter::Error = core::convert::Infallible
+pub fn supa_mdx_lint::output::markdown::MarkdownFormatter::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for supa_mdx_lint::output::markdown::MarkdownFormatter where U: core::convert::TryFrom<T>
+pub type supa_mdx_lint::output::markdown::MarkdownFormatter::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn supa_mdx_lint::output::markdown::MarkdownFormatter::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for supa_mdx_lint::output::markdown::MarkdownFormatter where T: core::clone::Clone
+pub type supa_mdx_lint::output::markdown::MarkdownFormatter::Owned = T
+pub fn supa_mdx_lint::output::markdown::MarkdownFormatter::clone_into(&self, target: &mut T)
+pub fn supa_mdx_lint::output::markdown::MarkdownFormatter::to_owned(&self) -> T
+impl<T> core::any::Any for supa_mdx_lint::output::markdown::MarkdownFormatter where T: 'static + ?core::marker::Sized
+pub fn supa_mdx_lint::output::markdown::MarkdownFormatter::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for supa_mdx_lint::output::markdown::MarkdownFormatter where T: ?core::marker::Sized
+pub fn supa_mdx_lint::output::markdown::MarkdownFormatter::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for supa_mdx_lint::output::markdown::MarkdownFormatter where T: ?core::marker::Sized
+pub fn supa_mdx_lint::output::markdown::MarkdownFormatter::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for supa_mdx_lint::output::markdown::MarkdownFormatter where T: core::clone::Clone
+pub unsafe fn supa_mdx_lint::output::markdown::MarkdownFormatter::clone_to_uninit(&self, dst: *mut u8)
+impl<T> core::convert::From<T> for supa_mdx_lint::output::markdown::MarkdownFormatter
+pub fn supa_mdx_lint::output::markdown::MarkdownFormatter::from(t: T) -> T
+impl<T> either::into_either::IntoEither for supa_mdx_lint::output::markdown::MarkdownFormatter
+pub mod supa_mdx_lint::output::rdf
+pub struct supa_mdx_lint::output::rdf::RdfFormatter
+impl core::clone::Clone for supa_mdx_lint::output::rdf::RdfFormatter
+pub fn supa_mdx_lint::output::rdf::RdfFormatter::clone(&self) -> supa_mdx_lint::output::rdf::RdfFormatter
+impl core::fmt::Debug for supa_mdx_lint::output::rdf::RdfFormatter
+pub fn supa_mdx_lint::output::rdf::RdfFormatter::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl supa_mdx_lint::output::OutputFormatter for supa_mdx_lint::output::rdf::RdfFormatter
+pub fn supa_mdx_lint::output::rdf::RdfFormatter::format(&self, outputs: &[supa_mdx_lint::output::LintOutput]) -> anyhow::Result<alloc::string::String>
+pub fn supa_mdx_lint::output::rdf::RdfFormatter::id(&self) -> &'static str
+pub fn supa_mdx_lint::output::rdf::RdfFormatter::should_log_metadata(&self) -> bool
+impl core::marker::Freeze for supa_mdx_lint::output::rdf::RdfFormatter
+impl core::marker::Send for supa_mdx_lint::output::rdf::RdfFormatter
+impl core::marker::Sync for supa_mdx_lint::output::rdf::RdfFormatter
+impl core::marker::Unpin for supa_mdx_lint::output::rdf::RdfFormatter
+impl core::panic::unwind_safe::RefUnwindSafe for supa_mdx_lint::output::rdf::RdfFormatter
+impl core::panic::unwind_safe::UnwindSafe for supa_mdx_lint::output::rdf::RdfFormatter
+impl<T, U> core::convert::Into<U> for supa_mdx_lint::output::rdf::RdfFormatter where U: core::convert::From<T>
+pub fn supa_mdx_lint::output::rdf::RdfFormatter::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for supa_mdx_lint::output::rdf::RdfFormatter where U: core::convert::Into<T>
+pub type supa_mdx_lint::output::rdf::RdfFormatter::Error = core::convert::Infallible
+pub fn supa_mdx_lint::output::rdf::RdfFormatter::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for supa_mdx_lint::output::rdf::RdfFormatter where U: core::convert::TryFrom<T>
+pub type supa_mdx_lint::output::rdf::RdfFormatter::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn supa_mdx_lint::output::rdf::RdfFormatter::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for supa_mdx_lint::output::rdf::RdfFormatter where T: core::clone::Clone
+pub type supa_mdx_lint::output::rdf::RdfFormatter::Owned = T
+pub fn supa_mdx_lint::output::rdf::RdfFormatter::clone_into(&self, target: &mut T)
+pub fn supa_mdx_lint::output::rdf::RdfFormatter::to_owned(&self) -> T
+impl<T> core::any::Any for supa_mdx_lint::output::rdf::RdfFormatter where T: 'static + ?core::marker::Sized
+pub fn supa_mdx_lint::output::rdf::RdfFormatter::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for supa_mdx_lint::output::rdf::RdfFormatter where T: ?core::marker::Sized
+pub fn supa_mdx_lint::output::rdf::RdfFormatter::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for supa_mdx_lint::output::rdf::RdfFormatter where T: ?core::marker::Sized
+pub fn supa_mdx_lint::output::rdf::RdfFormatter::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for supa_mdx_lint::output::rdf::RdfFormatter where T: core::clone::Clone
+pub unsafe fn supa_mdx_lint::output::rdf::RdfFormatter::clone_to_uninit(&self, dst: *mut u8)
+impl<T> core::convert::From<T> for supa_mdx_lint::output::rdf::RdfFormatter
+pub fn supa_mdx_lint::output::rdf::RdfFormatter::from(t: T) -> T
+impl<T> either::into_either::IntoEither for supa_mdx_lint::output::rdf::RdfFormatter
+pub mod supa_mdx_lint::output::simple
+pub struct supa_mdx_lint::output::simple::SimpleFormatter
+impl core::clone::Clone for supa_mdx_lint::output::simple::SimpleFormatter
+pub fn supa_mdx_lint::output::simple::SimpleFormatter::clone(&self) -> supa_mdx_lint::output::simple::SimpleFormatter
+impl core::fmt::Debug for supa_mdx_lint::output::simple::SimpleFormatter
+pub fn supa_mdx_lint::output::simple::SimpleFormatter::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl supa_mdx_lint::output::OutputFormatter for supa_mdx_lint::output::simple::SimpleFormatter
+pub fn supa_mdx_lint::output::simple::SimpleFormatter::format(&self, output: &[supa_mdx_lint::output::LintOutput]) -> anyhow::Result<alloc::string::String>
+pub fn supa_mdx_lint::output::simple::SimpleFormatter::id(&self) -> &'static str
+pub fn supa_mdx_lint::output::simple::SimpleFormatter::should_log_metadata(&self) -> bool
+impl core::marker::Freeze for supa_mdx_lint::output::simple::SimpleFormatter
+impl core::marker::Send for supa_mdx_lint::output::simple::SimpleFormatter
+impl core::marker::Sync for supa_mdx_lint::output::simple::SimpleFormatter
+impl core::marker::Unpin for supa_mdx_lint::output::simple::SimpleFormatter
+impl core::panic::unwind_safe::RefUnwindSafe for supa_mdx_lint::output::simple::SimpleFormatter
+impl core::panic::unwind_safe::UnwindSafe for supa_mdx_lint::output::simple::SimpleFormatter
+impl<T, U> core::convert::Into<U> for supa_mdx_lint::output::simple::SimpleFormatter where U: core::convert::From<T>
+pub fn supa_mdx_lint::output::simple::SimpleFormatter::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for supa_mdx_lint::output::simple::SimpleFormatter where U: core::convert::Into<T>
+pub type supa_mdx_lint::output::simple::SimpleFormatter::Error = core::convert::Infallible
+pub fn supa_mdx_lint::output::simple::SimpleFormatter::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for supa_mdx_lint::output::simple::SimpleFormatter where U: core::convert::TryFrom<T>
+pub type supa_mdx_lint::output::simple::SimpleFormatter::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn supa_mdx_lint::output::simple::SimpleFormatter::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for supa_mdx_lint::output::simple::SimpleFormatter where T: core::clone::Clone
+pub type supa_mdx_lint::output::simple::SimpleFormatter::Owned = T
+pub fn supa_mdx_lint::output::simple::SimpleFormatter::clone_into(&self, target: &mut T)
+pub fn supa_mdx_lint::output::simple::SimpleFormatter::to_owned(&self) -> T
+impl<T> core::any::Any for supa_mdx_lint::output::simple::SimpleFormatter where T: 'static + ?core::marker::Sized
+pub fn supa_mdx_lint::output::simple::SimpleFormatter::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for supa_mdx_lint::output::simple::SimpleFormatter where T: ?core::marker::Sized
+pub fn supa_mdx_lint::output::simple::SimpleFormatter::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for supa_mdx_lint::output::simple::SimpleFormatter where T: ?core::marker::Sized
+pub fn supa_mdx_lint::output::simple::SimpleFormatter::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for supa_mdx_lint::output::simple::SimpleFormatter where T: core::clone::Clone
+pub unsafe fn supa_mdx_lint::output::simple::SimpleFormatter::clone_to_uninit(&self, dst: *mut u8)
+impl<T> core::convert::From<T> for supa_mdx_lint::output::simple::SimpleFormatter
+pub fn supa_mdx_lint::output::simple::SimpleFormatter::from(t: T) -> T
+impl<T> either::into_either::IntoEither for supa_mdx_lint::output::simple::SimpleFormatter
+pub struct supa_mdx_lint::output::LintOutput
+impl supa_mdx_lint::output::LintOutput
+pub fn supa_mdx_lint::output::LintOutput::errors(&self) -> &[supa_mdx_lint::LintError]
+pub fn supa_mdx_lint::output::LintOutput::file_path(&self) -> &str
+impl core::fmt::Debug for supa_mdx_lint::output::LintOutput
+pub fn supa_mdx_lint::output::LintOutput::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for supa_mdx_lint::output::LintOutput
+impl core::marker::Send for supa_mdx_lint::output::LintOutput
+impl core::marker::Sync for supa_mdx_lint::output::LintOutput
+impl core::marker::Unpin for supa_mdx_lint::output::LintOutput
+impl core::panic::unwind_safe::RefUnwindSafe for supa_mdx_lint::output::LintOutput
+impl core::panic::unwind_safe::UnwindSafe for supa_mdx_lint::output::LintOutput
+impl<T, U> core::convert::Into<U> for supa_mdx_lint::output::LintOutput where U: core::convert::From<T>
+pub fn supa_mdx_lint::output::LintOutput::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for supa_mdx_lint::output::LintOutput where U: core::convert::Into<T>
+pub type supa_mdx_lint::output::LintOutput::Error = core::convert::Infallible
+pub fn supa_mdx_lint::output::LintOutput::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for supa_mdx_lint::output::LintOutput where U: core::convert::TryFrom<T>
+pub type supa_mdx_lint::output::LintOutput::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn supa_mdx_lint::output::LintOutput::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for supa_mdx_lint::output::LintOutput where T: 'static + ?core::marker::Sized
+pub fn supa_mdx_lint::output::LintOutput::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for supa_mdx_lint::output::LintOutput where T: ?core::marker::Sized
+pub fn supa_mdx_lint::output::LintOutput::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for supa_mdx_lint::output::LintOutput where T: ?core::marker::Sized
+pub fn supa_mdx_lint::output::LintOutput::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for supa_mdx_lint::output::LintOutput
+pub fn supa_mdx_lint::output::LintOutput::from(t: T) -> T
+impl<T> either::into_either::IntoEither for supa_mdx_lint::output::LintOutput
+pub struct supa_mdx_lint::output::OutputSummary
+pub supa_mdx_lint::output::OutputSummary::num_errors: usize
+pub supa_mdx_lint::output::OutputSummary::num_files: usize
+pub supa_mdx_lint::output::OutputSummary::num_warnings: usize
+impl core::marker::Freeze for supa_mdx_lint::output::OutputSummary
+impl core::marker::Send for supa_mdx_lint::output::OutputSummary
+impl core::marker::Sync for supa_mdx_lint::output::OutputSummary
+impl core::marker::Unpin for supa_mdx_lint::output::OutputSummary
+impl core::panic::unwind_safe::RefUnwindSafe for supa_mdx_lint::output::OutputSummary
+impl core::panic::unwind_safe::UnwindSafe for supa_mdx_lint::output::OutputSummary
+impl<T, U> core::convert::Into<U> for supa_mdx_lint::output::OutputSummary where U: core::convert::From<T>
+pub fn supa_mdx_lint::output::OutputSummary::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for supa_mdx_lint::output::OutputSummary where U: core::convert::Into<T>
+pub type supa_mdx_lint::output::OutputSummary::Error = core::convert::Infallible
+pub fn supa_mdx_lint::output::OutputSummary::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for supa_mdx_lint::output::OutputSummary where U: core::convert::TryFrom<T>
+pub type supa_mdx_lint::output::OutputSummary::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn supa_mdx_lint::output::OutputSummary::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for supa_mdx_lint::output::OutputSummary where T: 'static + ?core::marker::Sized
+pub fn supa_mdx_lint::output::OutputSummary::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for supa_mdx_lint::output::OutputSummary where T: ?core::marker::Sized
+pub fn supa_mdx_lint::output::OutputSummary::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for supa_mdx_lint::output::OutputSummary where T: ?core::marker::Sized
+pub fn supa_mdx_lint::output::OutputSummary::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for supa_mdx_lint::output::OutputSummary
+pub fn supa_mdx_lint::output::OutputSummary::from(t: T) -> T
+impl<T> either::into_either::IntoEither for supa_mdx_lint::output::OutputSummary
+pub trait supa_mdx_lint::output::OutputFormatter: core::marker::Send + core::marker::Sync + core::fmt::Debug
+pub fn supa_mdx_lint::output::OutputFormatter::format(&self, output: &[supa_mdx_lint::output::LintOutput]) -> anyhow::Result<alloc::string::String>
+pub fn supa_mdx_lint::output::OutputFormatter::get_summary(&self, output: &[supa_mdx_lint::output::LintOutput]) -> supa_mdx_lint::output::OutputSummary
+pub fn supa_mdx_lint::output::OutputFormatter::id(&self) -> &'static str
+pub fn supa_mdx_lint::output::OutputFormatter::should_log_metadata(&self) -> bool
+impl supa_mdx_lint::output::OutputFormatter for supa_mdx_lint::output::markdown::MarkdownFormatter
+pub fn supa_mdx_lint::output::markdown::MarkdownFormatter::format(&self, output: &[supa_mdx_lint::output::LintOutput]) -> anyhow::Result<alloc::string::String>
+pub fn supa_mdx_lint::output::markdown::MarkdownFormatter::id(&self) -> &'static str
+pub fn supa_mdx_lint::output::markdown::MarkdownFormatter::should_log_metadata(&self) -> bool
+impl supa_mdx_lint::output::OutputFormatter for supa_mdx_lint::output::rdf::RdfFormatter
+pub fn supa_mdx_lint::output::rdf::RdfFormatter::format(&self, outputs: &[supa_mdx_lint::output::LintOutput]) -> anyhow::Result<alloc::string::String>
+pub fn supa_mdx_lint::output::rdf::RdfFormatter::id(&self) -> &'static str
+pub fn supa_mdx_lint::output::rdf::RdfFormatter::should_log_metadata(&self) -> bool
+impl supa_mdx_lint::output::OutputFormatter for supa_mdx_lint::output::simple::SimpleFormatter
+pub fn supa_mdx_lint::output::simple::SimpleFormatter::format(&self, output: &[supa_mdx_lint::output::LintOutput]) -> anyhow::Result<alloc::string::String>
+pub fn supa_mdx_lint::output::simple::SimpleFormatter::id(&self) -> &'static str
+pub fn supa_mdx_lint::output::simple::SimpleFormatter::should_log_metadata(&self) -> bool
+pub mod supa_mdx_lint::rules
+pub struct supa_mdx_lint::rules::Rule001HeadingCase
+impl core::default::Default for supa_mdx_lint::rules::Rule001HeadingCase
+pub fn supa_mdx_lint::rules::Rule001HeadingCase::default() -> Self
+impl core::fmt::Debug for supa_mdx_lint::rules::Rule001HeadingCase
+pub fn supa_mdx_lint::rules::Rule001HeadingCase::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl !core::marker::Freeze for supa_mdx_lint::rules::Rule001HeadingCase
+impl core::marker::Send for supa_mdx_lint::rules::Rule001HeadingCase
+impl !core::marker::Sync for supa_mdx_lint::rules::Rule001HeadingCase
+impl core::marker::Unpin for supa_mdx_lint::rules::Rule001HeadingCase
+impl !core::panic::unwind_safe::RefUnwindSafe for supa_mdx_lint::rules::Rule001HeadingCase
+impl core::panic::unwind_safe::UnwindSafe for supa_mdx_lint::rules::Rule001HeadingCase
+impl<T, U> core::convert::Into<U> for supa_mdx_lint::rules::Rule001HeadingCase where U: core::convert::From<T>
+pub fn supa_mdx_lint::rules::Rule001HeadingCase::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for supa_mdx_lint::rules::Rule001HeadingCase where U: core::convert::Into<T>
+pub type supa_mdx_lint::rules::Rule001HeadingCase::Error = core::convert::Infallible
+pub fn supa_mdx_lint::rules::Rule001HeadingCase::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for supa_mdx_lint::rules::Rule001HeadingCase where U: core::convert::TryFrom<T>
+pub type supa_mdx_lint::rules::Rule001HeadingCase::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn supa_mdx_lint::rules::Rule001HeadingCase::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for supa_mdx_lint::rules::Rule001HeadingCase where T: 'static + ?core::marker::Sized
+pub fn supa_mdx_lint::rules::Rule001HeadingCase::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for supa_mdx_lint::rules::Rule001HeadingCase where T: ?core::marker::Sized
+pub fn supa_mdx_lint::rules::Rule001HeadingCase::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for supa_mdx_lint::rules::Rule001HeadingCase where T: ?core::marker::Sized
+pub fn supa_mdx_lint::rules::Rule001HeadingCase::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for supa_mdx_lint::rules::Rule001HeadingCase
+pub fn supa_mdx_lint::rules::Rule001HeadingCase::from(t: T) -> T
+impl<T> either::into_either::IntoEither for supa_mdx_lint::rules::Rule001HeadingCase
+pub struct supa_mdx_lint::rules::Rule002AdmonitionTypes
+impl core::default::Default for supa_mdx_lint::rules::Rule002AdmonitionTypes
+pub fn supa_mdx_lint::rules::Rule002AdmonitionTypes::default() -> supa_mdx_lint::rules::Rule002AdmonitionTypes
+impl core::fmt::Debug for supa_mdx_lint::rules::Rule002AdmonitionTypes
+pub fn supa_mdx_lint::rules::Rule002AdmonitionTypes::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for supa_mdx_lint::rules::Rule002AdmonitionTypes
+impl core::marker::Send for supa_mdx_lint::rules::Rule002AdmonitionTypes
+impl core::marker::Sync for supa_mdx_lint::rules::Rule002AdmonitionTypes
+impl core::marker::Unpin for supa_mdx_lint::rules::Rule002AdmonitionTypes
+impl core::panic::unwind_safe::RefUnwindSafe for supa_mdx_lint::rules::Rule002AdmonitionTypes
+impl core::panic::unwind_safe::UnwindSafe for supa_mdx_lint::rules::Rule002AdmonitionTypes
+impl<T, U> core::convert::Into<U> for supa_mdx_lint::rules::Rule002AdmonitionTypes where U: core::convert::From<T>
+pub fn supa_mdx_lint::rules::Rule002AdmonitionTypes::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for supa_mdx_lint::rules::Rule002AdmonitionTypes where U: core::convert::Into<T>
+pub type supa_mdx_lint::rules::Rule002AdmonitionTypes::Error = core::convert::Infallible
+pub fn supa_mdx_lint::rules::Rule002AdmonitionTypes::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for supa_mdx_lint::rules::Rule002AdmonitionTypes where U: core::convert::TryFrom<T>
+pub type supa_mdx_lint::rules::Rule002AdmonitionTypes::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn supa_mdx_lint::rules::Rule002AdmonitionTypes::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for supa_mdx_lint::rules::Rule002AdmonitionTypes where T: 'static + ?core::marker::Sized
+pub fn supa_mdx_lint::rules::Rule002AdmonitionTypes::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for supa_mdx_lint::rules::Rule002AdmonitionTypes where T: ?core::marker::Sized
+pub fn supa_mdx_lint::rules::Rule002AdmonitionTypes::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for supa_mdx_lint::rules::Rule002AdmonitionTypes where T: ?core::marker::Sized
+pub fn supa_mdx_lint::rules::Rule002AdmonitionTypes::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for supa_mdx_lint::rules::Rule002AdmonitionTypes
+pub fn supa_mdx_lint::rules::Rule002AdmonitionTypes::from(t: T) -> T
+impl<T> either::into_either::IntoEither for supa_mdx_lint::rules::Rule002AdmonitionTypes
+pub struct supa_mdx_lint::rules::Rule003Spelling
+impl core::default::Default for supa_mdx_lint::rules::Rule003Spelling
+pub fn supa_mdx_lint::rules::Rule003Spelling::default() -> supa_mdx_lint::rules::Rule003Spelling
+impl core::fmt::Debug for supa_mdx_lint::rules::Rule003Spelling
+pub fn supa_mdx_lint::rules::Rule003Spelling::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for supa_mdx_lint::rules::Rule003Spelling
+impl !core::marker::Send for supa_mdx_lint::rules::Rule003Spelling
+impl !core::marker::Sync for supa_mdx_lint::rules::Rule003Spelling
+impl core::marker::Unpin for supa_mdx_lint::rules::Rule003Spelling
+impl !core::panic::unwind_safe::RefUnwindSafe for supa_mdx_lint::rules::Rule003Spelling
+impl !core::panic::unwind_safe::UnwindSafe for supa_mdx_lint::rules::Rule003Spelling
+impl<T, U> core::convert::Into<U> for supa_mdx_lint::rules::Rule003Spelling where U: core::convert::From<T>
+pub fn supa_mdx_lint::rules::Rule003Spelling::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for supa_mdx_lint::rules::Rule003Spelling where U: core::convert::Into<T>
+pub type supa_mdx_lint::rules::Rule003Spelling::Error = core::convert::Infallible
+pub fn supa_mdx_lint::rules::Rule003Spelling::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for supa_mdx_lint::rules::Rule003Spelling where U: core::convert::TryFrom<T>
+pub type supa_mdx_lint::rules::Rule003Spelling::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn supa_mdx_lint::rules::Rule003Spelling::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for supa_mdx_lint::rules::Rule003Spelling where T: 'static + ?core::marker::Sized
+pub fn supa_mdx_lint::rules::Rule003Spelling::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for supa_mdx_lint::rules::Rule003Spelling where T: ?core::marker::Sized
+pub fn supa_mdx_lint::rules::Rule003Spelling::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for supa_mdx_lint::rules::Rule003Spelling where T: ?core::marker::Sized
+pub fn supa_mdx_lint::rules::Rule003Spelling::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for supa_mdx_lint::rules::Rule003Spelling
+pub fn supa_mdx_lint::rules::Rule003Spelling::from(t: T) -> T
+impl<T> either::into_either::IntoEither for supa_mdx_lint::rules::Rule003Spelling
+pub struct supa_mdx_lint::rules::Rule004ExcludeWords(_)
+impl core::default::Default for supa_mdx_lint::rules::Rule004ExcludeWords
+pub fn supa_mdx_lint::rules::Rule004ExcludeWords::default() -> supa_mdx_lint::rules::Rule004ExcludeWords
+impl core::fmt::Debug for supa_mdx_lint::rules::Rule004ExcludeWords
+pub fn supa_mdx_lint::rules::Rule004ExcludeWords::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for supa_mdx_lint::rules::Rule004ExcludeWords
+impl core::marker::Send for supa_mdx_lint::rules::Rule004ExcludeWords
+impl core::marker::Sync for supa_mdx_lint::rules::Rule004ExcludeWords
+impl core::marker::Unpin for supa_mdx_lint::rules::Rule004ExcludeWords
+impl core::panic::unwind_safe::RefUnwindSafe for supa_mdx_lint::rules::Rule004ExcludeWords
+impl core::panic::unwind_safe::UnwindSafe for supa_mdx_lint::rules::Rule004ExcludeWords
+impl<T, U> core::convert::Into<U> for supa_mdx_lint::rules::Rule004ExcludeWords where U: core::convert::From<T>
+pub fn supa_mdx_lint::rules::Rule004ExcludeWords::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for supa_mdx_lint::rules::Rule004ExcludeWords where U: core::convert::Into<T>
+pub type supa_mdx_lint::rules::Rule004ExcludeWords::Error = core::convert::Infallible
+pub fn supa_mdx_lint::rules::Rule004ExcludeWords::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for supa_mdx_lint::rules::Rule004ExcludeWords where U: core::convert::TryFrom<T>
+pub type supa_mdx_lint::rules::Rule004ExcludeWords::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn supa_mdx_lint::rules::Rule004ExcludeWords::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for supa_mdx_lint::rules::Rule004ExcludeWords where T: 'static + ?core::marker::Sized
+pub fn supa_mdx_lint::rules::Rule004ExcludeWords::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for supa_mdx_lint::rules::Rule004ExcludeWords where T: ?core::marker::Sized
+pub fn supa_mdx_lint::rules::Rule004ExcludeWords::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for supa_mdx_lint::rules::Rule004ExcludeWords where T: ?core::marker::Sized
+pub fn supa_mdx_lint::rules::Rule004ExcludeWords::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for supa_mdx_lint::rules::Rule004ExcludeWords
+pub fn supa_mdx_lint::rules::Rule004ExcludeWords::from(t: T) -> T
+impl<T> either::into_either::IntoEither for supa_mdx_lint::rules::Rule004ExcludeWords
+pub enum supa_mdx_lint::LintLevel
+pub supa_mdx_lint::LintLevel::Error
+pub supa_mdx_lint::LintLevel::Warning
+impl core::clone::Clone for supa_mdx_lint::LintLevel
+pub fn supa_mdx_lint::LintLevel::clone(&self) -> supa_mdx_lint::LintLevel
+impl core::cmp::Eq for supa_mdx_lint::LintLevel
+impl core::cmp::Ord for supa_mdx_lint::LintLevel
+pub fn supa_mdx_lint::LintLevel::cmp(&self, other: &supa_mdx_lint::LintLevel) -> core::cmp::Ordering
+impl core::cmp::PartialEq for supa_mdx_lint::LintLevel
+pub fn supa_mdx_lint::LintLevel::eq(&self, other: &supa_mdx_lint::LintLevel) -> bool
+impl core::cmp::PartialOrd for supa_mdx_lint::LintLevel
+pub fn supa_mdx_lint::LintLevel::partial_cmp(&self, other: &supa_mdx_lint::LintLevel) -> core::option::Option<core::cmp::Ordering>
+impl core::convert::TryFrom<&str> for supa_mdx_lint::LintLevel
+pub type supa_mdx_lint::LintLevel::Error = anyhow::Error
+pub fn supa_mdx_lint::LintLevel::try_from(value: &str) -> anyhow::Result<Self>
+impl core::default::Default for supa_mdx_lint::LintLevel
+pub fn supa_mdx_lint::LintLevel::default() -> supa_mdx_lint::LintLevel
+impl core::fmt::Debug for supa_mdx_lint::LintLevel
+pub fn supa_mdx_lint::LintLevel::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for supa_mdx_lint::LintLevel
+pub fn supa_mdx_lint::LintLevel::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for supa_mdx_lint::LintLevel
+impl core::marker::StructuralPartialEq for supa_mdx_lint::LintLevel
+impl serde::ser::Serialize for supa_mdx_lint::LintLevel
+pub fn supa_mdx_lint::LintLevel::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl<'de> serde::de::Deserialize<'de> for supa_mdx_lint::LintLevel
+pub fn supa_mdx_lint::LintLevel::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Freeze for supa_mdx_lint::LintLevel
+impl core::marker::Send for supa_mdx_lint::LintLevel
+impl core::marker::Sync for supa_mdx_lint::LintLevel
+impl core::marker::Unpin for supa_mdx_lint::LintLevel
+impl core::panic::unwind_safe::RefUnwindSafe for supa_mdx_lint::LintLevel
+impl core::panic::unwind_safe::UnwindSafe for supa_mdx_lint::LintLevel
+impl<Q, K> equivalent::Comparable<K> for supa_mdx_lint::LintLevel where Q: core::cmp::Ord + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn supa_mdx_lint::LintLevel::compare(&self, key: &K) -> core::cmp::Ordering
+impl<Q, K> equivalent::Equivalent<K> for supa_mdx_lint::LintLevel where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn supa_mdx_lint::LintLevel::equivalent(&self, key: &K) -> bool
+impl<Q, K> hashbrown::Equivalent<K> for supa_mdx_lint::LintLevel where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn supa_mdx_lint::LintLevel::equivalent(&self, key: &K) -> bool
+impl<T, U> core::convert::Into<U> for supa_mdx_lint::LintLevel where U: core::convert::From<T>
+pub fn supa_mdx_lint::LintLevel::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for supa_mdx_lint::LintLevel where U: core::convert::Into<T>
+pub type supa_mdx_lint::LintLevel::Error = core::convert::Infallible
+pub fn supa_mdx_lint::LintLevel::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for supa_mdx_lint::LintLevel where U: core::convert::TryFrom<T>
+pub type supa_mdx_lint::LintLevel::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn supa_mdx_lint::LintLevel::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for supa_mdx_lint::LintLevel where T: core::clone::Clone
+pub type supa_mdx_lint::LintLevel::Owned = T
+pub fn supa_mdx_lint::LintLevel::clone_into(&self, target: &mut T)
+pub fn supa_mdx_lint::LintLevel::to_owned(&self) -> T
+impl<T> alloc::string::ToString for supa_mdx_lint::LintLevel where T: core::fmt::Display + ?core::marker::Sized
+pub fn supa_mdx_lint::LintLevel::to_string(&self) -> alloc::string::String
+impl<T> core::any::Any for supa_mdx_lint::LintLevel where T: 'static + ?core::marker::Sized
+pub fn supa_mdx_lint::LintLevel::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for supa_mdx_lint::LintLevel where T: ?core::marker::Sized
+pub fn supa_mdx_lint::LintLevel::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for supa_mdx_lint::LintLevel where T: ?core::marker::Sized
+pub fn supa_mdx_lint::LintLevel::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for supa_mdx_lint::LintLevel where T: core::clone::Clone
+pub unsafe fn supa_mdx_lint::LintLevel::clone_to_uninit(&self, dst: *mut u8)
+impl<T> core::convert::From<T> for supa_mdx_lint::LintLevel
+pub fn supa_mdx_lint::LintLevel::from(t: T) -> T
+impl<T> either::into_either::IntoEither for supa_mdx_lint::LintLevel
+impl<T> serde::de::DeserializeOwned for supa_mdx_lint::LintLevel where T: for<'de> serde::de::Deserialize<'de>
+pub enum supa_mdx_lint::LintTarget<'a>
+pub supa_mdx_lint::LintTarget::FileOrDirectory(std::path::PathBuf)
+pub supa_mdx_lint::LintTarget::String(&'a str)
+impl<'a> core::fmt::Debug for supa_mdx_lint::LintTarget<'a>
+pub fn supa_mdx_lint::LintTarget<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<'a> core::marker::Freeze for supa_mdx_lint::LintTarget<'a>
+impl<'a> core::marker::Send for supa_mdx_lint::LintTarget<'a>
+impl<'a> core::marker::Sync for supa_mdx_lint::LintTarget<'a>
+impl<'a> core::marker::Unpin for supa_mdx_lint::LintTarget<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for supa_mdx_lint::LintTarget<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for supa_mdx_lint::LintTarget<'a>
+impl<T, U> core::convert::Into<U> for supa_mdx_lint::LintTarget<'a> where U: core::convert::From<T>
+pub fn supa_mdx_lint::LintTarget<'a>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for supa_mdx_lint::LintTarget<'a> where U: core::convert::Into<T>
+pub type supa_mdx_lint::LintTarget<'a>::Error = core::convert::Infallible
+pub fn supa_mdx_lint::LintTarget<'a>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for supa_mdx_lint::LintTarget<'a> where U: core::convert::TryFrom<T>
+pub type supa_mdx_lint::LintTarget<'a>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn supa_mdx_lint::LintTarget<'a>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for supa_mdx_lint::LintTarget<'a> where T: 'static + ?core::marker::Sized
+pub fn supa_mdx_lint::LintTarget<'a>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for supa_mdx_lint::LintTarget<'a> where T: ?core::marker::Sized
+pub fn supa_mdx_lint::LintTarget<'a>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for supa_mdx_lint::LintTarget<'a> where T: ?core::marker::Sized
+pub fn supa_mdx_lint::LintTarget<'a>::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for supa_mdx_lint::LintTarget<'a>
+pub fn supa_mdx_lint::LintTarget<'a>::from(t: T) -> T
+impl<T> either::into_either::IntoEither for supa_mdx_lint::LintTarget<'a>
+pub struct supa_mdx_lint::Config
+impl supa_mdx_lint::Config
+pub fn supa_mdx_lint::Config::from_config_file<P: core::convert::AsRef<std::path::Path>>(config_file: P) -> anyhow::Result<Self>
+pub fn supa_mdx_lint::Config::from_serializable<T: serde::ser::Serialize>(config: T, config_dir: &supa_mdx_lint::ConfigDir) -> anyhow::Result<Self>
+impl core::default::Default for supa_mdx_lint::Config
+pub fn supa_mdx_lint::Config::default() -> Self
+impl core::fmt::Debug for supa_mdx_lint::Config
+pub fn supa_mdx_lint::Config::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for supa_mdx_lint::Config
+impl !core::marker::Send for supa_mdx_lint::Config
+impl !core::marker::Sync for supa_mdx_lint::Config
+impl core::marker::Unpin for supa_mdx_lint::Config
+impl !core::panic::unwind_safe::RefUnwindSafe for supa_mdx_lint::Config
+impl !core::panic::unwind_safe::UnwindSafe for supa_mdx_lint::Config
+impl<T, U> core::convert::Into<U> for supa_mdx_lint::Config where U: core::convert::From<T>
+pub fn supa_mdx_lint::Config::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for supa_mdx_lint::Config where U: core::convert::Into<T>
+pub type supa_mdx_lint::Config::Error = core::convert::Infallible
+pub fn supa_mdx_lint::Config::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for supa_mdx_lint::Config where U: core::convert::TryFrom<T>
+pub type supa_mdx_lint::Config::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn supa_mdx_lint::Config::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for supa_mdx_lint::Config where T: 'static + ?core::marker::Sized
+pub fn supa_mdx_lint::Config::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for supa_mdx_lint::Config where T: ?core::marker::Sized
+pub fn supa_mdx_lint::Config::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for supa_mdx_lint::Config where T: ?core::marker::Sized
+pub fn supa_mdx_lint::Config::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for supa_mdx_lint::Config
+pub fn supa_mdx_lint::Config::from(t: T) -> T
+impl<T> either::into_either::IntoEither for supa_mdx_lint::Config
+pub struct supa_mdx_lint::ConfigDir(_)
+impl supa_mdx_lint::ConfigDir
+pub fn supa_mdx_lint::ConfigDir::new(path: std::path::PathBuf) -> Self
+pub fn supa_mdx_lint::ConfigDir::none() -> Self
+impl core::clone::Clone for supa_mdx_lint::ConfigDir
+pub fn supa_mdx_lint::ConfigDir::clone(&self) -> supa_mdx_lint::ConfigDir
+impl core::fmt::Debug for supa_mdx_lint::ConfigDir
+pub fn supa_mdx_lint::ConfigDir::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for supa_mdx_lint::ConfigDir
+impl core::marker::Send for supa_mdx_lint::ConfigDir
+impl core::marker::Sync for supa_mdx_lint::ConfigDir
+impl core::marker::Unpin for supa_mdx_lint::ConfigDir
+impl core::panic::unwind_safe::RefUnwindSafe for supa_mdx_lint::ConfigDir
+impl core::panic::unwind_safe::UnwindSafe for supa_mdx_lint::ConfigDir
+impl<T, U> core::convert::Into<U> for supa_mdx_lint::ConfigDir where U: core::convert::From<T>
+pub fn supa_mdx_lint::ConfigDir::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for supa_mdx_lint::ConfigDir where U: core::convert::Into<T>
+pub type supa_mdx_lint::ConfigDir::Error = core::convert::Infallible
+pub fn supa_mdx_lint::ConfigDir::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for supa_mdx_lint::ConfigDir where U: core::convert::TryFrom<T>
+pub type supa_mdx_lint::ConfigDir::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn supa_mdx_lint::ConfigDir::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for supa_mdx_lint::ConfigDir where T: core::clone::Clone
+pub type supa_mdx_lint::ConfigDir::Owned = T
+pub fn supa_mdx_lint::ConfigDir::clone_into(&self, target: &mut T)
+pub fn supa_mdx_lint::ConfigDir::to_owned(&self) -> T
+impl<T> core::any::Any for supa_mdx_lint::ConfigDir where T: 'static + ?core::marker::Sized
+pub fn supa_mdx_lint::ConfigDir::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for supa_mdx_lint::ConfigDir where T: ?core::marker::Sized
+pub fn supa_mdx_lint::ConfigDir::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for supa_mdx_lint::ConfigDir where T: ?core::marker::Sized
+pub fn supa_mdx_lint::ConfigDir::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for supa_mdx_lint::ConfigDir where T: core::clone::Clone
+pub unsafe fn supa_mdx_lint::ConfigDir::clone_to_uninit(&self, dst: *mut u8)
+impl<T> core::convert::From<T> for supa_mdx_lint::ConfigDir
+pub fn supa_mdx_lint::ConfigDir::from(t: T) -> T
+impl<T> either::into_either::IntoEither for supa_mdx_lint::ConfigDir
+pub struct supa_mdx_lint::LintError
+impl supa_mdx_lint::LintError
+pub fn supa_mdx_lint::LintError::combined_suggestions(&self) -> core::option::Option<alloc::vec::Vec<&supa_mdx_lint::fix::LintCorrection>>
+pub fn supa_mdx_lint::LintError::level(&self) -> supa_mdx_lint::LintLevel
+pub fn supa_mdx_lint::LintError::message(&self) -> &str
+pub fn supa_mdx_lint::LintError::offset_range(&self) -> core::ops::range::Range<usize>
+impl core::clone::Clone for supa_mdx_lint::LintError
+pub fn supa_mdx_lint::LintError::clone(&self) -> supa_mdx_lint::LintError
+impl core::fmt::Debug for supa_mdx_lint::LintError
+pub fn supa_mdx_lint::LintError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl serde::ser::Serialize for supa_mdx_lint::LintError
+pub fn supa_mdx_lint::LintError::serialize<__S>(&self, __serializer: __S) -> core::result::Result<<__S as serde::ser::Serializer>::Ok, <__S as serde::ser::Serializer>::Error> where __S: serde::ser::Serializer
+impl supa_mdx_lint::geometry::Offsets for supa_mdx_lint::LintError
+pub fn supa_mdx_lint::LintError::end(&self) -> usize
+pub fn supa_mdx_lint::LintError::start(&self) -> usize
+impl<'de> serde::de::Deserialize<'de> for supa_mdx_lint::LintError
+pub fn supa_mdx_lint::LintError::deserialize<__D>(__deserializer: __D) -> core::result::Result<Self, <__D as serde::de::Deserializer>::Error> where __D: serde::de::Deserializer<'de>
+impl core::marker::Freeze for supa_mdx_lint::LintError
+impl core::marker::Send for supa_mdx_lint::LintError
+impl core::marker::Sync for supa_mdx_lint::LintError
+impl core::marker::Unpin for supa_mdx_lint::LintError
+impl core::panic::unwind_safe::RefUnwindSafe for supa_mdx_lint::LintError
+impl core::panic::unwind_safe::UnwindSafe for supa_mdx_lint::LintError
+impl<T, U> core::convert::Into<U> for supa_mdx_lint::LintError where U: core::convert::From<T>
+pub fn supa_mdx_lint::LintError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for supa_mdx_lint::LintError where U: core::convert::Into<T>
+pub type supa_mdx_lint::LintError::Error = core::convert::Infallible
+pub fn supa_mdx_lint::LintError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for supa_mdx_lint::LintError where U: core::convert::TryFrom<T>
+pub type supa_mdx_lint::LintError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn supa_mdx_lint::LintError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for supa_mdx_lint::LintError where T: core::clone::Clone
+pub type supa_mdx_lint::LintError::Owned = T
+pub fn supa_mdx_lint::LintError::clone_into(&self, target: &mut T)
+pub fn supa_mdx_lint::LintError::to_owned(&self) -> T
+impl<T> core::any::Any for supa_mdx_lint::LintError where T: 'static + ?core::marker::Sized
+pub fn supa_mdx_lint::LintError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for supa_mdx_lint::LintError where T: ?core::marker::Sized
+pub fn supa_mdx_lint::LintError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for supa_mdx_lint::LintError where T: ?core::marker::Sized
+pub fn supa_mdx_lint::LintError::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for supa_mdx_lint::LintError where T: core::clone::Clone
+pub unsafe fn supa_mdx_lint::LintError::clone_to_uninit(&self, dst: *mut u8)
+impl<T> core::convert::From<T> for supa_mdx_lint::LintError
+pub fn supa_mdx_lint::LintError::from(t: T) -> T
+impl<T> either::into_either::IntoEither for supa_mdx_lint::LintError
+impl<T> serde::de::DeserializeOwned for supa_mdx_lint::LintError where T: for<'de> serde::de::Deserialize<'de>
+pub struct supa_mdx_lint::Linter
+impl supa_mdx_lint::Linter
+pub fn supa_mdx_lint::Linter::builder() -> supa_mdx_lint::LinterBuilder
+pub fn supa_mdx_lint::Linter::is_ignored(&self, path: impl core::convert::AsRef<std::path::Path>) -> bool
+pub fn supa_mdx_lint::Linter::is_lintable(&self, path: impl core::convert::AsRef<std::path::Path>) -> bool
+pub fn supa_mdx_lint::Linter::lint(&self, input: &supa_mdx_lint::LintTarget<'_>) -> anyhow::Result<alloc::vec::Vec<supa_mdx_lint::output::LintOutput>>
+pub fn supa_mdx_lint::Linter::lint_only_rule(&self, rule_id: &str, input: &supa_mdx_lint::LintTarget<'_>) -> anyhow::Result<alloc::vec::Vec<supa_mdx_lint::output::LintOutput>>
+impl supa_mdx_lint::Linter
+pub fn supa_mdx_lint::Linter::fix(&self, diagnostics: &[supa_mdx_lint::output::LintOutput]) -> anyhow::Result<(usize, usize)>
+impl core::fmt::Debug for supa_mdx_lint::Linter
+pub fn supa_mdx_lint::Linter::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for supa_mdx_lint::Linter
+impl !core::marker::Send for supa_mdx_lint::Linter
+impl !core::marker::Sync for supa_mdx_lint::Linter
+impl core::marker::Unpin for supa_mdx_lint::Linter
+impl !core::panic::unwind_safe::RefUnwindSafe for supa_mdx_lint::Linter
+impl !core::panic::unwind_safe::UnwindSafe for supa_mdx_lint::Linter
+impl<T, U> core::convert::Into<U> for supa_mdx_lint::Linter where U: core::convert::From<T>
+pub fn supa_mdx_lint::Linter::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for supa_mdx_lint::Linter where U: core::convert::Into<T>
+pub type supa_mdx_lint::Linter::Error = core::convert::Infallible
+pub fn supa_mdx_lint::Linter::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for supa_mdx_lint::Linter where U: core::convert::TryFrom<T>
+pub type supa_mdx_lint::Linter::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn supa_mdx_lint::Linter::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for supa_mdx_lint::Linter where T: 'static + ?core::marker::Sized
+pub fn supa_mdx_lint::Linter::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for supa_mdx_lint::Linter where T: ?core::marker::Sized
+pub fn supa_mdx_lint::Linter::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for supa_mdx_lint::Linter where T: ?core::marker::Sized
+pub fn supa_mdx_lint::Linter::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for supa_mdx_lint::Linter
+pub fn supa_mdx_lint::Linter::from(t: T) -> T
+impl<T> either::into_either::IntoEither for supa_mdx_lint::Linter
+pub struct supa_mdx_lint::LinterBuilder<S: supa_mdx_lint::linter_builder::State>
+impl<S: supa_mdx_lint::linter_builder::State> supa_mdx_lint::LinterBuilder<S>
+pub fn supa_mdx_lint::LinterBuilder<S>::build(self) -> anyhow::Result<supa_mdx_lint::Linter> where S: supa_mdx_lint::linter_builder::IsComplete
+pub fn supa_mdx_lint::LinterBuilder<S>::config(self, value: supa_mdx_lint::Config) -> supa_mdx_lint::LinterBuilder<supa_mdx_lint::linter_builder::SetConfig<S>> where <S as supa_mdx_lint::linter_builder::State>::Config: bon::builder_state::IsUnset
+pub fn supa_mdx_lint::LinterBuilder<S>::maybe_config(self, value: core::option::Option<supa_mdx_lint::Config>) -> supa_mdx_lint::LinterBuilder<supa_mdx_lint::linter_builder::SetConfig<S>> where <S as supa_mdx_lint::linter_builder::State>::Config: bon::builder_state::IsUnset
+impl<S> core::marker::Freeze for supa_mdx_lint::LinterBuilder<S>
+impl<S> !core::marker::Send for supa_mdx_lint::LinterBuilder<S>
+impl<S> !core::marker::Sync for supa_mdx_lint::LinterBuilder<S>
+impl<S> core::marker::Unpin for supa_mdx_lint::LinterBuilder<S>
+impl<S> !core::panic::unwind_safe::RefUnwindSafe for supa_mdx_lint::LinterBuilder<S>
+impl<S> !core::panic::unwind_safe::UnwindSafe for supa_mdx_lint::LinterBuilder<S>
+impl<T, U> core::convert::Into<U> for supa_mdx_lint::LinterBuilder<S> where U: core::convert::From<T>
+pub fn supa_mdx_lint::LinterBuilder<S>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for supa_mdx_lint::LinterBuilder<S> where U: core::convert::Into<T>
+pub type supa_mdx_lint::LinterBuilder<S>::Error = core::convert::Infallible
+pub fn supa_mdx_lint::LinterBuilder<S>::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for supa_mdx_lint::LinterBuilder<S> where U: core::convert::TryFrom<T>
+pub type supa_mdx_lint::LinterBuilder<S>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn supa_mdx_lint::LinterBuilder<S>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for supa_mdx_lint::LinterBuilder<S> where T: 'static + ?core::marker::Sized
+pub fn supa_mdx_lint::LinterBuilder<S>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for supa_mdx_lint::LinterBuilder<S> where T: ?core::marker::Sized
+pub fn supa_mdx_lint::LinterBuilder<S>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for supa_mdx_lint::LinterBuilder<S> where T: ?core::marker::Sized
+pub fn supa_mdx_lint::LinterBuilder<S>::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for supa_mdx_lint::LinterBuilder<S>
+pub fn supa_mdx_lint::LinterBuilder<S>::from(t: T) -> T
+impl<T> either::into_either::IntoEither for supa_mdx_lint::LinterBuilder<S>

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,27 +5,7 @@ pub(crate) mod path;
 pub(crate) mod regex;
 pub(crate) mod words;
 
-use std::{borrow::Cow, path::Path};
-
-pub fn is_lintable(path: impl AsRef<Path>) -> bool {
-    let path = path.as_ref();
-    path.is_dir() || path.extension().map_or(false, |ext| ext == "mdx")
-}
-
-pub trait Offsets {
-    fn start(&self) -> usize;
-    fn end(&self) -> usize;
-}
-
-impl<T: Offsets> Offsets for &T {
-    fn start(&self) -> usize {
-        (*self).start()
-    }
-
-    fn end(&self) -> usize {
-        (*self).end()
-    }
-}
+use std::borrow::Cow;
 
 pub(crate) fn num_digits(n: usize) -> usize {
     if n == 0 {


### PR DESCRIPTION
chore: clean up public api

Public API was under a lot of flux so it exposed some things that should be internal and hid some things that should be exposed. Cleaning up to expose a more reasonable public surface.

Breaking change in major version 0 so next release will bump minor version.

ci: add public api snapshots

To make sure we don't make a mess of the public API and it progresses towards better and better stability, add a snapshot test for the public API.