### PR TITLE
fix(rule001): Bug with ignores containing regexes + clippy cleanup

### DIFF
--- a/src/comments.rs
+++ b/src/comments.rs
@@ -615,7 +615,7 @@ A list:
         let first = comment_pairs.first().unwrap();
         assert_eq!(first.0.inner.value, "/* Comment 1 */");
         match first.1 {
-            Some(Node::Paragraph(Paragraph { children, .. })) => match children.get(0).unwrap() {
+            Some(Node::Paragraph(Paragraph { children, .. })) => match children.first().unwrap() {
                 Node::Text(text) => {
                     assert_eq!(text.value, "Paragraph 1");
                 }
@@ -631,7 +631,7 @@ A list:
         let second = comment_pairs.get(1).unwrap();
         assert_eq!(second.0.inner.value, "/* Comment 2 */");
         match second.1 {
-            Some(Node::Paragraph(Paragraph { children, .. })) => match children.get(0).unwrap() {
+            Some(Node::Paragraph(Paragraph { children, .. })) => match children.first().unwrap() {
                 Node::Text(text) => {
                     assert_eq!(text.value, "Paragraph 1");
                 }
@@ -647,8 +647,8 @@ A list:
         let third = comment_pairs.get(2).unwrap();
         assert_eq!(third.0.inner.value, "/* Comment 3 */");
         match third.1 {
-            Some(Node::ListItem(list_item)) => match list_item.children.get(0).unwrap() {
-                Node::Paragraph(Paragraph { children, .. }) => match children.get(0).unwrap() {
+            Some(Node::ListItem(list_item)) => match list_item.children.first().unwrap() {
+                Node::Paragraph(Paragraph { children, .. }) => match children.first().unwrap() {
                     Node::Text(text) => {
                         assert_eq!(text.value, "Item 2");
                     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -536,7 +536,7 @@ option2 = "value"
         let locations = metadata.config_file_locations.unwrap();
 
         assert!(locations.len() == 1);
-        assert!(locations.get(VALID_RULE_NAME).is_some());
+        assert!(locations.contains_key(VALID_RULE_NAME));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,7 +49,7 @@ impl ConfigFileLocations {
         }
     }
 
-    fn iter(&self) -> ConfigFileLocationsIterator {
+    fn iter(&self) -> ConfigFileLocationsIterator<'_> {
         ConfigFileLocationsIterator {
             inner: self.0.as_ref().map(|map| map.iter()),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,10 +201,10 @@ mod tests {
             .deactivate_all_but("Rule001HeadingCase");
 
         let valid_mdx = "# Hello, world!\n\nThis is a valid document.";
-        let result = linter.lint(&LintTarget::String(&valid_mdx.to_string()))?;
+        let result = linter.lint(&LintTarget::String(valid_mdx))?;
 
         assert!(
-            result.get(0).unwrap().errors().is_empty(),
+            result.first().unwrap().errors().is_empty(),
             "Expected no lint errors for valid MDX, got {:?}",
             result
         );
@@ -220,10 +220,10 @@ mod tests {
             .deactivate_all_but("Rule001HeadingCase");
 
         let invalid_mdx = "# Incorrect Heading\n\nThis is an invalid document.";
-        let result = linter.lint(&LintTarget::String(&invalid_mdx.to_string()))?;
+        let result = linter.lint(&LintTarget::String(invalid_mdx))?;
 
         assert!(
-            !result.get(0).unwrap().errors().is_empty(),
+            !result.first().unwrap().errors().is_empty(),
             "Expected lint errors for invalid MDX"
         );
         Ok(())

--- a/src/output/markdown.rs
+++ b/src/output/markdown.rs
@@ -218,7 +218,7 @@ mod tests {
     ) -> Result<String> {
         let temp_dir = TempDir::new().unwrap();
         let file_path = temp_dir.path().join(mock_path);
-        fs::write(&file_path, &contents).unwrap();
+        fs::write(&file_path, contents).unwrap();
 
         let error = LintError::from_raw_location()
             .rule(rule_name)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -206,7 +206,7 @@ Content here."#;
         let yaml = frontmatter.downcast_ref::<serde_yaml::Value>().unwrap();
         if let serde_yaml::Value::Mapping(map) = yaml {
             assert_eq!(map.len(), 1);
-            assert!(map.contains_key(&serde_yaml::Value::String("title".to_string())));
+            assert!(map.contains_key(serde_yaml::Value::String("title".to_string())));
         } else {
             panic!("Expected YAML frontmatter to be a mapping");
         }

--- a/src/rules/rule001_heading_case.rs
+++ b/src/rules/rule001_heading_case.rs
@@ -362,13 +362,13 @@ mod tests {
         let errors = result.unwrap();
         assert_eq!(errors.len(), 1);
 
-        let fixes = errors.get(0).unwrap().fix.clone();
+        let fixes = errors.first().unwrap().fix.clone();
         assert!(fixes.is_some());
 
         let fixes = fixes.unwrap();
         assert_eq!(fixes.len(), 1);
 
-        let fix = fixes.get(0).unwrap();
+        let fix = fixes.first().unwrap();
         match fix {
             LintCorrection::Replace(fix) => {
                 assert_eq!(fix.text, "This");
@@ -403,13 +403,13 @@ mod tests {
         let errors = result.unwrap();
         assert_eq!(errors.len(), 1);
 
-        let fixes = errors.get(0).unwrap().fix.clone();
+        let fixes = errors.first().unwrap().fix.clone();
         assert!(fixes.is_some());
 
         let fixes = fixes.unwrap();
         assert_eq!(fixes.len(), 2);
 
-        let fix_one = fixes.get(0).unwrap();
+        let fix_one = fixes.first().unwrap();
         match fix_one {
             LintCorrection::Replace(fix) => {
                 assert_eq!(fix.text, "should");
@@ -657,11 +657,11 @@ mod tests {
         let result = result.unwrap();
         assert_eq!(result.len(), 1);
 
-        let error = result.get(0).unwrap();
+        let error = result.first().unwrap();
         assert_eq!(error.fix.as_ref().unwrap().len(), 1);
 
         let fixes = error.fix.clone().unwrap();
-        let fix = fixes.get(0).unwrap();
+        let fix = fixes.first().unwrap();
         match fix {
             LintCorrection::Replace(fix) => {
                 assert_eq!(fix.text, "api");
@@ -885,8 +885,8 @@ mod tests {
             )
             .unwrap();
 
-        let fixes = result.get(0).unwrap().fix.as_ref().unwrap();
-        let fix = fixes.get(0).unwrap();
+        let fixes = result.first().unwrap().fix.as_ref().unwrap();
+        let fix = fixes.first().unwrap();
         match fix {
             LintCorrection::Replace(fix) => {
                 assert_eq!(fix.location.start.column, 8);

--- a/src/rules/rule001_heading_case.rs
+++ b/src/rules/rule001_heading_case.rs
@@ -212,21 +212,30 @@ impl Rule001HeadingCase {
 
         let text = rope.to_string();
         debug!("Checking for exceptions in {text}");
+
+        let mut longest_match: Option<regex::Match<'_>> = None;
         for pattern in patterns {
             if let Some(match_result) = pattern.find(&text) {
                 debug!("Found exception match: {match_result:?}");
-                while offset + match_result.len()
-                    > word_iterator
-                        .curr_index()
-                        .expect("WordIterator index should not be queried while unstable")
-                {
-                    if word_iterator.next().is_none() {
-                        break;
-                    }
+                if longest_match.is_none() || match_result.len() > longest_match.unwrap().len() {
+                    longest_match = Some(match_result);
                 }
-
-                return true;
             }
+        }
+
+        if let Some(match_result) = longest_match {
+            debug!("Using longest exception match: {match_result:?}");
+            while offset + match_result.len()
+                > word_iterator
+                    .curr_index()
+                    .expect("WordIterator index should not be queried while unstable")
+            {
+                if word_iterator.next().is_none() {
+                    break;
+                }
+            }
+
+            return true;
         }
 
         false
@@ -508,6 +517,56 @@ mod tests {
             &context,
             LintLevel::Error,
         );
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_rule001_exception_including_initialism() {
+        let mut rule = Rule001HeadingCase::default();
+        let mut settings =
+            RuleSettings::with_array_of_strings("may_uppercase", vec!["MCP Inspector"]);
+        rule.setup(Some(&mut settings));
+
+        let mdx = "### Test with MCP Inspector";
+        let parse_result = parse(mdx).unwrap();
+        let context = Context::builder()
+            .parse_result(&parse_result)
+            .build()
+            .unwrap();
+
+        let result = rule.check(
+            parse_result.ast().children().unwrap().first().unwrap(),
+            &context,
+            LintLevel::Error,
+        );
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_rule001_longer_exception_preferred_over_regex() {
+        // Regression test: when a regex like "[A-Z]{2,5}" could match "MCP" but
+        // a longer literal "MCP Inspector" also matches, the longer match should win.
+        let mut rule = Rule001HeadingCase::default();
+        let mut settings = RuleSettings::with_array_of_strings(
+            "may_uppercase",
+            vec!["[A-Z]{2,5}", "MCP Inspector"],
+        );
+        rule.setup(Some(&mut settings));
+
+        let mdx = "#### Test with MCP Inspector";
+        let parse_result = parse(mdx).unwrap();
+        let context = Context::builder()
+            .parse_result(&parse_result)
+            .build()
+            .unwrap();
+
+        let result = rule.check(
+            parse_result.ast().children().unwrap().first().unwrap(),
+            &context,
+            LintLevel::Error,
+        );
+        // Should pass because "MCP Inspector" is matched as a whole,
+        // not just "MCP" leaving "Inspector" unmatched.
         assert!(result.is_none());
     }
 

--- a/src/rules/rule002_admonition_types.rs
+++ b/src/rules/rule002_admonition_types.rs
@@ -197,14 +197,13 @@ Some text.
             .parse_result
             .ast()
             .children()
-            .unwrap()
-            .get(0)
+            .unwrap().first()
             .unwrap();
         let result = rule.check(admonition, &context, LintLevel::Error);
 
         assert!(result.is_some());
         assert!(result.as_ref().unwrap().len() == 1);
-        let location = &result.as_ref().unwrap().get(0).unwrap().location;
+        let location = &result.as_ref().unwrap().first().unwrap().location;
         assert!(location.start.row == 4);
         assert!(location.start.column == 12);
         assert!(location.end.row == 4);
@@ -228,8 +227,7 @@ Some text.
             .parse_result
             .ast()
             .children()
-            .unwrap()
-            .get(0)
+            .unwrap().first()
             .unwrap();
         let result = rule.check(admonition, &context, LintLevel::Error);
 
@@ -243,8 +241,9 @@ Some text.
 Some text.
 </Admonition>"#;
 
-        let mut rule = Rule002AdmonitionTypes::default();
-        rule.admonition_types = vec!["note".to_string()];
+        let rule = Rule002AdmonitionTypes {
+            admonition_types: vec!["note".to_string()],
+        };
         let parse_result = parse(mdx).unwrap();
         let context = Context::builder()
             .parse_result(&parse_result)
@@ -255,8 +254,7 @@ Some text.
             .parse_result
             .ast()
             .children()
-            .unwrap()
-            .get(0)
+            .unwrap().first()
             .unwrap();
         let result = rule.check(admonition, &context, LintLevel::Error);
 

--- a/src/rules/rule003_spelling.rs
+++ b/src/rules/rule003_spelling.rs
@@ -544,12 +544,10 @@ mod tests {
             parse_result
                 .ast()
                 .children()
-                .unwrap()
-                .get(0)
+                .unwrap().first()
                 .unwrap()
                 .children()
-                .unwrap()
-                .get(0)
+                .unwrap().first()
                 .unwrap(),
             &context,
             LintLevel::Error,
@@ -574,12 +572,10 @@ mod tests {
                 parse_result
                     .ast()
                     .children()
-                    .unwrap()
-                    .get(0)
+                    .unwrap().first()
                     .unwrap()
                     .children()
-                    .unwrap()
-                    .get(0)
+                    .unwrap().first()
                     .unwrap(),
                 &context,
                 LintLevel::Error,
@@ -610,12 +606,10 @@ mod tests {
             parse_result
                 .ast()
                 .children()
-                .unwrap()
-                .get(0)
+                .unwrap().first()
                 .unwrap()
                 .children()
-                .unwrap()
-                .get(0)
+                .unwrap().first()
                 .unwrap(),
             &context,
             LintLevel::Error,
@@ -640,12 +634,10 @@ mod tests {
             parse_result
                 .ast()
                 .children()
-                .unwrap()
-                .get(0)
+                .unwrap().first()
                 .unwrap()
                 .children()
-                .unwrap()
-                .get(0)
+                .unwrap().first()
                 .unwrap(),
             &context,
             LintLevel::Error,
@@ -670,12 +662,10 @@ mod tests {
             parse_result
                 .ast()
                 .children()
-                .unwrap()
-                .get(0)
+                .unwrap().first()
                 .unwrap()
                 .children()
-                .unwrap()
-                .get(0)
+                .unwrap().first()
                 .unwrap(),
             &context,
             LintLevel::Error,
@@ -700,12 +690,10 @@ mod tests {
                 parse_result
                     .ast()
                     .children()
-                    .unwrap()
-                    .get(0)
+                    .unwrap().first()
                     .unwrap()
                     .children()
-                    .unwrap()
-                    .get(0)
+                    .unwrap().first()
                     .unwrap(),
                 &context,
                 LintLevel::Error,
@@ -742,12 +730,10 @@ mod tests {
                 parse_result
                     .ast()
                     .children()
-                    .unwrap()
-                    .get(0)
+                    .unwrap().first()
                     .unwrap()
                     .children()
-                    .unwrap()
-                    .get(0)
+                    .unwrap().first()
                     .unwrap(),
                 &context,
                 LintLevel::Error,
@@ -778,12 +764,10 @@ mod tests {
                 parse_result
                     .ast()
                     .children()
-                    .unwrap()
-                    .get(0)
+                    .unwrap().first()
                     .unwrap()
                     .children()
-                    .unwrap()
-                    .get(0)
+                    .unwrap().first()
                     .unwrap(),
                 &context,
                 LintLevel::Error,
@@ -814,12 +798,10 @@ mod tests {
             parse_result
                 .ast()
                 .children()
-                .unwrap()
-                .get(0)
+                .unwrap().first()
                 .unwrap()
                 .children()
-                .unwrap()
-                .get(0)
+                .unwrap().first()
                 .unwrap(),
             &context,
             LintLevel::Error,
@@ -844,12 +826,10 @@ mod tests {
             parse_result
                 .ast()
                 .children()
-                .unwrap()
-                .get(0)
+                .unwrap().first()
                 .unwrap()
                 .children()
-                .unwrap()
-                .get(0)
+                .unwrap().first()
                 .unwrap(),
             &context,
             LintLevel::Error,
@@ -875,12 +855,10 @@ mod tests {
             parse_result
                 .ast()
                 .children()
-                .unwrap()
-                .get(0)
+                .unwrap().first()
                 .unwrap()
                 .children()
-                .unwrap()
-                .get(0)
+                .unwrap().first()
                 .unwrap(),
             &context,
             LintLevel::Error,
@@ -904,12 +882,10 @@ mod tests {
             parse_result
                 .ast()
                 .children()
-                .unwrap()
-                .get(0)
+                .unwrap().first()
                 .unwrap()
                 .children()
-                .unwrap()
-                .get(0)
+                .unwrap().first()
                 .unwrap(),
             &context,
             LintLevel::Error,
@@ -934,12 +910,10 @@ mod tests {
             parse_result
                 .ast()
                 .children()
-                .unwrap()
-                .get(0)
+                .unwrap().first()
                 .unwrap()
                 .children()
-                .unwrap()
-                .get(0)
+                .unwrap().first()
                 .unwrap(),
             &context,
             LintLevel::Error,
@@ -964,12 +938,10 @@ mod tests {
                 parse_result
                     .ast()
                     .children()
-                    .unwrap()
-                    .get(0)
+                    .unwrap().first()
                     .unwrap()
                     .children()
-                    .unwrap()
-                    .get(0)
+                    .unwrap().first()
                     .unwrap(),
                 &context,
                 LintLevel::Error,

--- a/src/rules/rule003_spelling.rs
+++ b/src/rules/rule003_spelling.rs
@@ -477,7 +477,7 @@ impl Rule003Spelling {
         AdjustedRange::new(start, end)
     }
 
-    fn normalize_word(word: &str) -> Cow<str> {
+    fn normalize_word(word: &str) -> Cow<'_, str> {
         let mut word = Cow::Borrowed(word);
 
         let quote_chars = ['‘', '’', '“', '”'];

--- a/src/rules/rule004_exclude_words.rs
+++ b/src/rules/rule004_exclude_words.rs
@@ -864,7 +864,7 @@ mod tests {
         let errors = result.unwrap();
         assert_eq!(errors.len(), 1);
 
-        let error = errors.get(0).unwrap();
+        let error = errors.first().unwrap();
         assert_eq!(error.message, "Don't use 'Foo'");
         assert_eq!(error.level, LintLevel::Error);
         assert_eq!(error.location.offset_range.start, AdjustedOffset::from(10));
@@ -898,7 +898,7 @@ mod tests {
         let errors = result.unwrap();
         assert_eq!(errors.len(), 1);
 
-        let error = errors.get(0).unwrap();
+        let error = errors.first().unwrap();
         assert_eq!(error.message, "Don't use 'Foo'");
         assert_eq!(error.level, LintLevel::Error);
         assert_eq!(error.location.offset_range.start, AdjustedOffset::from(10));
@@ -907,7 +907,7 @@ mod tests {
         assert!(error.suggestions.is_some());
         let suggestions = error.suggestions.as_ref().unwrap();
         assert_eq!(suggestions.len(), 1);
-        let suggestion = suggestions.get(0).unwrap();
+        let suggestion = suggestions.first().unwrap();
         assert!(matches!(
             suggestion,
             LintCorrection::Replace(LintCorrectionReplace { .. })
@@ -949,7 +949,7 @@ mod tests {
         let errors = result.unwrap();
         assert_eq!(errors.len(), 2);
 
-        let error = errors.get(0).unwrap();
+        let error = errors.first().unwrap();
         assert_eq!(error.message, "Don't use 'Foo'");
         assert_eq!(error.level, LintLevel::Error);
         assert_eq!(error.location.offset_range.start, AdjustedOffset::from(10));
@@ -986,7 +986,7 @@ mod tests {
         let errors = result.unwrap();
         assert_eq!(errors.len(), 1);
 
-        let error = errors.get(0).unwrap();
+        let error = errors.first().unwrap();
         assert_eq!(error.message, "Don't use 'Foo bar'");
         assert_eq!(error.level, LintLevel::Error);
         assert_eq!(error.location.offset_range.start, AdjustedOffset::from(10));
@@ -1028,7 +1028,7 @@ mod tests {
         let errors = result.unwrap();
         assert_eq!(errors.len(), 1);
 
-        let error = errors.get(0).unwrap();
+        let error = errors.first().unwrap();
         assert_eq!(error.message, "Don't use 'bartender'");
         assert_eq!(error.level, LintLevel::Error);
         assert_eq!(error.location.offset_range.start, AdjustedOffset::from(14));
@@ -1072,7 +1072,7 @@ mod tests {
         let errors = result.unwrap();
         assert_eq!(errors.len(), 1);
 
-        let error = errors.get(0).unwrap();
+        let error = errors.first().unwrap();
         assert_eq!(error.message, "Don't use 'Foo bartender'");
         assert_eq!(error.level, LintLevel::Error);
         assert_eq!(error.location.offset_range.start, AdjustedOffset::from(10));
@@ -1132,7 +1132,7 @@ mod tests {
         let errors = result.unwrap();
         assert_eq!(errors.len(), 1);
 
-        let error = errors.get(0).unwrap();
+        let error = errors.first().unwrap();
         assert_eq!(error.message, "Don't use 'Foo bartender'");
         assert_eq!(error.level, LintLevel::Error);
         assert_eq!(error.location.offset_range.start, AdjustedOffset::from(10));
@@ -1185,7 +1185,7 @@ mod tests {
         let errors = result.unwrap();
         assert_eq!(errors.len(), 1);
 
-        let error = errors.get(0).unwrap();
+        let error = errors.first().unwrap();
         assert_eq!(error.message, "Don't use 'foo'");
         assert_eq!(error.level, LintLevel::Error);
         assert_eq!(error.location.offset_range.start, AdjustedOffset::from(10));
@@ -1216,7 +1216,7 @@ mod tests {
         let errors = result.unwrap();
         assert_eq!(errors.len(), 1);
 
-        let error = errors.get(0).unwrap();
+        let error = errors.first().unwrap();
         assert_eq!(error.message, "Don't use 'foo'");
         assert_eq!(error.level, LintLevel::Warning);
         assert_eq!(error.location.offset_range.start, AdjustedOffset::from(10));
@@ -1247,7 +1247,7 @@ mod tests {
         let errors = result.unwrap();
         assert_eq!(errors.len(), 1);
 
-        let error = errors.get(0).unwrap();
+        let error = errors.first().unwrap();
         assert_eq!(error.message, "blah blah blah");
         assert_eq!(error.level, LintLevel::Error);
         assert_eq!(error.location.offset_range.start, AdjustedOffset::from(0));
@@ -1278,7 +1278,7 @@ mod tests {
         let errors = result.unwrap();
         assert_eq!(errors.len(), 1);
 
-        let error = errors.get(0).unwrap();
+        let error = errors.first().unwrap();
         assert_eq!(error.message, "This isn't Reddit.");
         assert_eq!(error.level, LintLevel::Error);
         assert_eq!(error.location.offset_range.start, AdjustedOffset::from(0));
@@ -1309,7 +1309,7 @@ mod tests {
         let errors = result.unwrap();
         assert_eq!(errors.len(), 1);
 
-        let error = errors.get(0).unwrap();
+        let error = errors.first().unwrap();
         assert_eq!(error.message, "Don't use ladeeda");
     }
 
@@ -1337,7 +1337,7 @@ mod tests {
         let errors = result.unwrap();
         assert_eq!(errors.len(), 1);
 
-        let error = errors.get(0).unwrap();
+        let error = errors.first().unwrap();
         assert_eq!(error.message, "Don't use %%s");
     }
 
@@ -1368,7 +1368,7 @@ mod tests {
         let errors = result.unwrap();
         assert_eq!(errors.len(), 1);
 
-        let error = errors.get(0).unwrap();
+        let error = errors.first().unwrap();
         assert_eq!(error.message, "Use Postgres instead of PostgreSQL");
     }
 
@@ -1396,8 +1396,8 @@ mod tests {
         let errors = result.unwrap();
         assert_eq!(errors.len(), 1);
 
-        let error = errors.get(0).unwrap();
-        let suggestion = error.suggestions.as_ref().unwrap().get(0).unwrap();
+        let error = errors.first().unwrap();
+        let suggestion = error.suggestions.as_ref().unwrap().first().unwrap();
         match suggestion {
             LintCorrection::Replace(replace) => {
                 assert_eq!(replace.location.offset_range.start, AdjustedOffset::from(0));

--- a/src/rules/rule004_exclude_words.rs
+++ b/src/rules/rule004_exclude_words.rs
@@ -694,7 +694,7 @@ fn combine_exclusions<'a>(
 ) -> Peekable<impl Iterator<Item = (usize, Suffix<'a>, CaseSensitivity, &'a Option<String>)>> {
     fn remainders_iter(
         details: &WordExclusionMeta,
-    ) -> impl Iterator<Item = (usize, Suffix, &Option<String>)> {
+    ) -> impl Iterator<Item = (usize, Suffix<'_>, &Option<String>)> {
         details.remainders.iter().enumerate().map(|(i, rem)| {
             let (rule_index, replacement) = details
                 .details

--- a/src/rules/rule005_admonition_newlines.rs
+++ b/src/rules/rule005_admonition_newlines.rs
@@ -237,7 +237,7 @@ This is the content.
 
 </Admonition>"#;
 
-        let rule = Rule005AdmonitionNewlines::default();
+        let rule = Rule005AdmonitionNewlines;
         let parse_result = parse(mdx).unwrap();
         let context = Context::builder()
             .parse_result(&parse_result)
@@ -248,8 +248,7 @@ This is the content.
             .parse_result
             .ast()
             .children()
-            .unwrap()
-            .get(0)
+            .unwrap().first()
             .unwrap();
         let result = rule.check(admonition, &context, LintLevel::Error);
 
@@ -265,7 +264,7 @@ This is the content.
 This is the content.
 </Admonition>"#;
 
-        let rule = Rule005AdmonitionNewlines::default();
+        let rule = Rule005AdmonitionNewlines;
         let parse_result = parse(mdx).unwrap();
         let context = Context::builder()
             .parse_result(&parse_result)
@@ -276,8 +275,7 @@ This is the content.
             .parse_result
             .ast()
             .children()
-            .unwrap()
-            .get(0)
+            .unwrap().first()
             .unwrap();
         let result = rule.check(admonition, &context, LintLevel::Error);
 
@@ -300,7 +298,7 @@ This is the content.
 
 </Admonition>"#;
 
-        let rule = Rule005AdmonitionNewlines::default();
+        let rule = Rule005AdmonitionNewlines;
         let parse_result = parse(mdx).unwrap();
         let context = Context::builder()
             .parse_result(&parse_result)
@@ -311,8 +309,7 @@ This is the content.
             .parse_result
             .ast()
             .children()
-            .unwrap()
-            .get(0)
+            .unwrap().first()
             .unwrap();
         let result = rule.check(admonition, &context, LintLevel::Error);
 
@@ -335,7 +332,7 @@ This is the content.
 This is the content.
 </Admonition>"#;
 
-        let rule = Rule005AdmonitionNewlines::default();
+        let rule = Rule005AdmonitionNewlines;
         let parse_result = parse(mdx).unwrap();
         let context = Context::builder()
             .parse_result(&parse_result)
@@ -346,8 +343,7 @@ This is the content.
             .parse_result
             .ast()
             .children()
-            .unwrap()
-            .get(0)
+            .unwrap().first()
             .unwrap();
         let result = rule.check(admonition, &context, LintLevel::Error);
 
@@ -370,7 +366,7 @@ This is the content.
 
 </Admonition>"#;
 
-        let rule = Rule005AdmonitionNewlines::default();
+        let rule = Rule005AdmonitionNewlines;
         let parse_result = parse(mdx).unwrap();
         let context = Context::builder()
             .parse_result(&parse_result)
@@ -381,8 +377,7 @@ This is the content.
             .parse_result
             .ast()
             .children()
-            .unwrap()
-            .get(0)
+            .unwrap().first()
             .unwrap();
         let result = rule.check(admonition, &context, LintLevel::Error);
 
@@ -418,7 +413,7 @@ This is the content.
 This is the content.
 </Admonition>"#;
 
-        let rule = Rule005AdmonitionNewlines::default();
+        let rule = Rule005AdmonitionNewlines;
         let parse_result = parse(mdx).unwrap();
         let context = Context::builder()
             .parse_result(&parse_result)
@@ -429,8 +424,7 @@ This is the content.
             .parse_result
             .ast()
             .children()
-            .unwrap()
-            .get(0)
+            .unwrap().first()
             .unwrap();
         let result = rule.check(admonition, &context, LintLevel::Error);
 
@@ -465,7 +459,7 @@ This is the content.
 This is the content.
 </Admonition>"#;
 
-        let rule = Rule005AdmonitionNewlines::default();
+        let rule = Rule005AdmonitionNewlines;
         let parse_result = parse(mdx).unwrap();
         let context = Context::builder()
             .parse_result(&parse_result)
@@ -476,8 +470,7 @@ This is the content.
             .parse_result
             .ast()
             .children()
-            .unwrap()
-            .get(0)
+            .unwrap().first()
             .unwrap();
         let result = rule.check(admonition, &context, LintLevel::Error);
 
@@ -525,7 +518,7 @@ This is the content.
 
 </Admonition>"#;
 
-        let rule = Rule005AdmonitionNewlines::default();
+        let rule = Rule005AdmonitionNewlines;
         let parse_result = parse(mdx).unwrap();
         let context = Context::builder()
             .parse_result(&parse_result)
@@ -536,8 +529,7 @@ This is the content.
             .parse_result
             .ast()
             .children()
-            .unwrap()
-            .get(0)
+            .unwrap().first()
             .unwrap();
         let result = rule.check(admonition, &context, LintLevel::Error);
 
@@ -552,7 +544,7 @@ This is the content.
         let mdx =
             r#"<Admonition type="note" label="Data changes are not merged into production." />"#;
 
-        let rule = Rule005AdmonitionNewlines::default();
+        let rule = Rule005AdmonitionNewlines;
         let parse_result = parse(mdx).unwrap();
         let context = Context::builder()
             .parse_result(&parse_result)
@@ -563,8 +555,7 @@ This is the content.
             .parse_result
             .ast()
             .children()
-            .unwrap()
-            .get(0)
+            .unwrap().first()
             .unwrap();
         let result = rule.check(admonition, &context, LintLevel::Error);
 

--- a/src/utils/lru.rs
+++ b/src/utils/lru.rs
@@ -100,8 +100,10 @@ mod tests {
 
     #[test]
     fn test_lru_cache_eviction() {
-        let mut cache = LruCache::<String, i32>::default();
-        cache.capacity = 3;
+        let mut cache = LruCache::<String, i32> {
+            capacity: 3,
+            ..Default::default()
+        };
 
         // Fill the cache
         cache.insert("a".to_string(), 1);

--- a/src/utils/words.rs
+++ b/src/utils/words.rs
@@ -1114,9 +1114,7 @@ mod tests {
         let mut orig_iter: extras::WordIteratorExtension<'_, extras::WordIteratorPrefix> =
             WordIterator::new(slice, 0, Default::default()).into();
 
-        let mut consumed = vec![];
-        consumed.push(orig_iter.next().unwrap());
-        consumed.push(orig_iter.next().unwrap());
+        let consumed = vec![orig_iter.next().unwrap(), orig_iter.next().unwrap()];
 
         let mut new_iter = orig_iter.extend_on_prefix(extras::WordIteratorPrefix::new(consumed));
 

--- a/tests/rule001/mod.rs
+++ b/tests/rule001/mod.rs
@@ -1,0 +1,16 @@
+use std::process::Command;
+
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+
+#[test]
+fn integration_test_rule001_exception_including_initialism() {
+    let mut cmd = Command::cargo_bin("supa-mdx-lint").unwrap();
+    cmd.arg("tests/rule001/rule001.mdx")
+        .arg("--config")
+        .arg("tests/rule001/supa-mdx-lint.config.toml");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("No errors or warnings found"));
+}

--- a/tests/rule001/rule001.mdx
+++ b/tests/rule001/rule001.mdx
@@ -1,0 +1,1 @@
+#### Test with MCP Inspector

--- a/tests/rule001/supa-mdx-lint.config.toml
+++ b/tests/rule001/supa-mdx-lint.config.toml
@@ -1,0 +1,10 @@
+Rule002AdmonitionTypes = false
+Rule003Spelling = false
+Rule004ExcludeWords = false
+Rule005AdmonitionNewlines = false
+Rule006NoAbsoluteUrls = false
+
+[Rule001HeadingCase]
+# Include a regex that could match "MCP" and a longer literal "MCP Inspector"
+# The longer match should be preferred
+may_uppercase = ["[A-Z]{2,5}", "MCP Inspector"]

--- a/tests/rules.rs
+++ b/tests/rules.rs
@@ -1,3 +1,4 @@
+mod rule001;
 mod rule002;
 mod rule003;
 mod rule004;


### PR DESCRIPTION
## Summary

- **Fixed a bug in Rule001HeadingCase** where regex-based exceptions in `may_uppercase` could incorrectly fail to match multi-word phrases when a shorter regex pattern matched first
- **Fixed Clippy diagnostics** across the codebase

## The Bug

When multiple patterns in `may_uppercase` could match text (e.g., `[A-Z]{2,5}` matching "MCP" and `MCP Inspector` matching the full phrase), the rule would use the first match found rather than the longest match. This caused false positives:

**Before:** A heading like `#### Test with MCP Inspector` with config `may_uppercase = ["[A-Z]{2,5}", "MCP Inspector"]` would fail because:
1. The regex `[A-Z]{2,5}` would match "MCP" first
2. The word iterator would advance past "MCP"
3. "Inspector" would be left unmatched and flagged as a casing error

**After:** All patterns are checked and the **longest match** is selected, so "MCP Inspector" is correctly recognized as a single exception.

## Changes

### Bug Fix (`src/rules/rule001_heading_case.rs`)
- Modified `check_exceptions_at_current_word` to collect all matches and select the longest one
- Added unit tests for the fix
- Added integration test with config file to verify end-to-end behavior

### Clippy Cleanup
- `.get(0).unwrap()` → `.first().unwrap()` (more idiomatic)
- Added explicit lifetime annotations where Clippy recommended
- `map.get(key).is_some()` → `map.contains_key(key)`
- Removed unnecessary borrows/references
- Used direct struct initialization instead of mutating after `Default::default()`

## Test Plan

- [x] New unit tests pass: `test_rule001_exception_including_initialism` and `test_rule001_longer_exception_preferred_over_regex`
- [x] New integration test passes: `integration_test_rule001_exception_including_initialism`
- [x] All existing tests pass
- [x] `cargo clippy` produces no warnings