### PR TITLE
chore: update node in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
-          node-version: "20.10.0"
+          node-version: "22.22.0"
           registry-url: "https://registry.npmjs.org"
           scope: "supabase"
 


### PR DESCRIPTION
Node 20 is reaching end of life in April, and is also too old to run the `npm install npm@latest` that comes next. Updating to the latest 22 (LTS for the next year+)