### PR TITLE
reject headings inside admonitions

### DIFF
--- a/src/rules.rs
+++ b/src/rules.rs
@@ -20,6 +20,7 @@ mod rule003_spelling;
 mod rule004_exclude_words;
 mod rule005_admonition_newlines;
 mod rule006_no_absolute_urls;
+mod rule007_no_headings_in_admonitions;
 
 pub use rule001_heading_case::Rule001HeadingCase;
 pub use rule002_admonition_types::Rule002AdmonitionTypes;
@@ -27,6 +28,7 @@ pub use rule003_spelling::Rule003Spelling;
 pub use rule004_exclude_words::Rule004ExcludeWords;
 pub use rule005_admonition_newlines::Rule005AdmonitionNewlines;
 pub use rule006_no_absolute_urls::Rule006NoAbsoluteUrls;
+pub use rule007_no_headings_in_admonitions::Rule007NoHeadingsInAdmonitions;
 
 fn get_all_rules() -> Vec<Box<dyn Rule>> {
     vec![
@@ -36,6 +38,7 @@ fn get_all_rules() -> Vec<Box<dyn Rule>> {
         Box::new(Rule004ExcludeWords::default()),
         Box::new(Rule005AdmonitionNewlines),
         Box::new(Rule006NoAbsoluteUrls::default()),
+        Box::new(Rule007NoHeadingsInAdmonitions),
     ]
 }
 

--- a/src/rules/rule005_admonition_newlines.rs
+++ b/src/rules/rule005_admonition_newlines.rs
@@ -19,10 +19,10 @@ struct ErrorInfo {
     fixes: Vec<LintCorrection>,
 }
 
-static ADMONITION_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?s)<Admonition[^>]*>\s*\r?\n\s*\r?\n.*?\r?\n\s*\r?\n\s*</Admonition>")
-        .unwrap()
-});
+static OPENING_SEPARATION_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\r?\n[ \t]*\r?\n[ \t]*$").unwrap());
+static AFTER_OPENING_SEPARATION_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^\r?\n[ \t]*\r?\n").unwrap());
 
 /// Admonition JSX tags must have empty line separation from their content.
 ///
@@ -113,9 +113,24 @@ impl Rule005AdmonitionNewlines {
         let admonition_content = admonition_slice.to_string();
         debug!("Admonition content: {:?}", admonition_content);
 
-        // Check if the content matches the valid pattern
-        if !self.has_proper_newlines(&admonition_content) {
-            let fixes = self.generate_fixes(&admonition_content, &adjusted_range, context);
+        let opening_tag_end = find_opening_tag_end(&admonition_content)?;
+        let content_after_opening = &admonition_content[opening_tag_end..];
+        let closing_tag_offset = admonition_content.rfind("</Admonition>")?;
+        let content_before_closing = &admonition_content[..closing_tag_offset];
+
+        let has_opening_separation = starts_with_blank_line(content_after_opening);
+        let has_closing_separation = OPENING_SEPARATION_PATTERN.is_match(content_before_closing);
+
+        if !has_opening_separation || !has_closing_separation {
+            let fixes = self.generate_fixes(
+                &admonition_content,
+                content_after_opening,
+                opening_tag_end,
+                content_before_closing,
+                closing_tag_offset,
+                &adjusted_range,
+                context,
+            );
             return Some(ErrorInfo {
                 message: "Admonition must have empty lines between tags and content".to_string(),
                 fixes,
@@ -125,64 +140,36 @@ impl Rule005AdmonitionNewlines {
         None
     }
 
-    fn has_proper_newlines(&self, content: &str) -> bool {
-        let matches = ADMONITION_PATTERN.is_match(content);
-        debug!(
-            "Pattern match result for content {:?}: {}",
-            content, matches
-        );
-
-        matches
-    }
-
     fn generate_fixes(
         &self,
         content: &str,
+        content_after_opening: &str,
+        opening_tag_end: usize,
+        content_before_closing: &str,
+        closing_tag_offset: usize,
         adjusted_range: &AdjustedRange,
         context: &Context,
     ) -> Vec<LintCorrection> {
-        let lines: Vec<&str> = content.lines().collect();
-        if lines.is_empty() {
-            return Vec::new();
-        }
-
         // Detect the line ending style used in the content
         let line_ending = if content.contains("\r\n") {
             "\r\n"
         } else {
             "\n"
         };
-        let line_ending_len = line_ending.len();
 
         let mut fix_list = Vec::new();
 
-        let opening_tag_line = 0;
-        let closing_tag_line = lines.len() - 1;
-
-        // Check if we need to add an empty line after the opening tag
-        let needs_opening_newline = if lines.len() >= 2 {
-            // Check if there's content immediately after the opening tag (no empty line)
-            !lines[1].trim().is_empty()
-        } else {
-            false
-        };
-
-        // Check if we need to add an empty line before the closing tag
-        let needs_closing_newline = if closing_tag_line > 0 {
-            // Check if there's content immediately before the closing tag (no empty line)
-            !lines[closing_tag_line - 1].trim().is_empty()
-        } else {
-            false
-        };
-
-        // Add fix for opening newline
-        if needs_opening_newline {
-            // Position after the opening tag line + its newline
-            let relative_offset = lines[opening_tag_line].len() + line_ending_len;
-
+        if !starts_with_blank_line(content_after_opening) {
+            let (insertion_offset, missing_line_endings) =
+                if content_after_opening.starts_with("\r\n") {
+                    (opening_tag_end + 2, 1)
+                } else if content_after_opening.starts_with('\n') {
+                    (opening_tag_end + 1, 1)
+                } else {
+                    (opening_tag_end, 2)
+                };
             let mut start_point = adjusted_range.start;
-            start_point.increment(relative_offset);
-
+            start_point.increment(insertion_offset);
             let location = DenormalizedLocation::from_offset_range(
                 AdjustedRange::new(start_point, start_point),
                 context,
@@ -190,24 +177,18 @@ impl Rule005AdmonitionNewlines {
 
             fix_list.push(LintCorrection::Insert(LintCorrectionInsert {
                 location,
-                text: line_ending.to_string(),
+                text: line_ending.repeat(missing_line_endings),
             }));
         }
 
-        // Add fix for closing newline
-        if needs_closing_newline {
-            // Calculate relative position at the start of the closing tag line
-            let mut relative_offset = 0;
-            for (i, line) in lines.iter().enumerate() {
-                if i == closing_tag_line {
-                    break;
-                }
-                relative_offset += line.len() + line_ending_len;
-            }
-
+        if !OPENING_SEPARATION_PATTERN.is_match(content_before_closing) {
+            let missing_line_endings = if content_before_closing.ends_with('\n') {
+                1
+            } else {
+                2
+            };
             let mut start_point = adjusted_range.start;
-            start_point.increment(relative_offset);
-
+            start_point.increment(closing_tag_offset);
             let location = DenormalizedLocation::from_offset_range(
                 AdjustedRange::new(start_point, start_point),
                 context,
@@ -215,12 +196,51 @@ impl Rule005AdmonitionNewlines {
 
             fix_list.push(LintCorrection::Insert(LintCorrectionInsert {
                 location,
-                text: line_ending.to_string(),
+                text: line_ending.repeat(missing_line_endings),
             }));
         }
 
         fix_list
     }
+}
+
+fn starts_with_blank_line(content: &str) -> bool {
+    AFTER_OPENING_SEPARATION_PATTERN.is_match(content)
+}
+
+fn find_opening_tag_end(content: &str) -> Option<usize> {
+    let mut brace_depth: usize = 0;
+    let mut quote = None;
+    let mut escaped = false;
+
+    for (offset, character) in content.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        if character == '\\' && quote.is_some() {
+            escaped = true;
+            continue;
+        }
+
+        if let Some(active_quote) = quote {
+            if character == active_quote {
+                quote = None;
+            }
+            continue;
+        }
+
+        match character {
+            '"' | '\'' | '`' => quote = Some(character),
+            '{' => brace_depth += 1,
+            '}' => brace_depth = brace_depth.saturating_sub(1),
+            '>' if brace_depth == 0 => return Some(offset + character.len_utf8()),
+            _ => {}
+        }
+    }
+
+    None
 }
 
 #[cfg(test)]
@@ -256,6 +276,38 @@ This is the content.
             result.is_none(),
             "Expected no lint errors for valid admonition"
         );
+    }
+
+    #[test]
+    fn test_rule005_valid_admonition_with_jsx_action() {
+        let mdx = r#"<Admonition
+  type="note"
+  actions={
+    <Button>Continue</Button>
+  }
+>
+
+This is the content.
+
+</Admonition>"#;
+
+        let rule = Rule005AdmonitionNewlines;
+        let parse_result = parse(mdx).unwrap();
+        let context = Context::builder()
+            .parse_result(&parse_result)
+            .build()
+            .unwrap();
+        let admonition = context
+            .parse_result
+            .ast()
+            .children()
+            .unwrap()
+            .first()
+            .unwrap();
+
+        assert!(rule
+            .check(admonition, &context, LintLevel::Error)
+            .is_none());
     }
 
     #[test]

--- a/src/rules/rule005_admonition_newlines.rs
+++ b/src/rules/rule005_admonition_newlines.rs
@@ -22,7 +22,7 @@ struct ErrorInfo {
 static OPENING_SEPARATION_PATTERN: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\r?\n[ \t]*\r?\n[ \t]*$").unwrap());
 static AFTER_OPENING_SEPARATION_PATTERN: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^\r?\n[ \t]*\r?\n").unwrap());
+    LazyLock::new(|| Regex::new(r"^[ \t]*\r?\n[ \t]*\r?\n").unwrap());
 
 /// Admonition JSX tags must have empty line separation from their content.
 ///
@@ -160,14 +160,13 @@ impl Rule005AdmonitionNewlines {
         let mut fix_list = Vec::new();
 
         if !starts_with_blank_line(content_after_opening) {
-            let (insertion_offset, missing_line_endings) =
-                if content_after_opening.starts_with("\r\n") {
-                    (opening_tag_end + 2, 1)
-                } else if content_after_opening.starts_with('\n') {
-                    (opening_tag_end + 1, 1)
-                } else {
-                    (opening_tag_end, 2)
-                };
+            let (insertion_offset, missing_line_endings) = if let Some(first_line_end) =
+                first_line_ending_after_horizontal_whitespace(content_after_opening)
+            {
+                (opening_tag_end + first_line_end, 1)
+            } else {
+                (opening_tag_end, 2)
+            };
             let mut start_point = adjusted_range.start;
             start_point.increment(insertion_offset);
             let location = DenormalizedLocation::from_offset_range(
@@ -206,6 +205,22 @@ impl Rule005AdmonitionNewlines {
 
 fn starts_with_blank_line(content: &str) -> bool {
     AFTER_OPENING_SEPARATION_PATTERN.is_match(content)
+}
+
+fn first_line_ending_after_horizontal_whitespace(content: &str) -> Option<usize> {
+    let whitespace_len = content
+        .bytes()
+        .take_while(|byte| matches!(byte, b' ' | b'\t'))
+        .count();
+    let content_after_whitespace = &content[whitespace_len..];
+
+    if content_after_whitespace.starts_with("\r\n") {
+        Some(whitespace_len + 2)
+    } else if content_after_whitespace.starts_with('\n') {
+        Some(whitespace_len + 1)
+    } else {
+        None
+    }
 }
 
 fn find_opening_tag_end(content: &str) -> Option<usize> {
@@ -308,6 +323,56 @@ This is the content.
         assert!(rule
             .check(admonition, &context, LintLevel::Error)
             .is_none());
+    }
+
+    #[test]
+    fn test_rule005_valid_admonition_with_trailing_opening_whitespace() {
+        let mdx = "<Admonition type=\"note\">  \t\n\t\nBody.\n\n</Admonition>";
+
+        let rule = Rule005AdmonitionNewlines;
+        let parse_result = parse(mdx).unwrap();
+        let context = Context::builder()
+            .parse_result(&parse_result)
+            .build()
+            .unwrap();
+        let admonition = context
+            .parse_result
+            .ast()
+            .children()
+            .unwrap().first()
+            .unwrap();
+
+        assert!(rule.check(admonition, &context, LintLevel::Error).is_none());
+    }
+
+    #[test]
+    fn test_rule005_auto_fix_missing_opening_empty_line_with_trailing_whitespace() {
+        let mdx = "<Admonition type=\"note\">  \t\nBody.\n\n</Admonition>";
+
+        let rule = Rule005AdmonitionNewlines;
+        let parse_result = parse(mdx).unwrap();
+        let context = Context::builder()
+            .parse_result(&parse_result)
+            .build()
+            .unwrap();
+        let admonition = context
+            .parse_result
+            .ast()
+            .children()
+            .unwrap().first()
+            .unwrap();
+        let errors = rule.check(admonition, &context, LintLevel::Error).unwrap();
+        let fixes = errors[0].fix.as_ref().unwrap();
+
+        assert_eq!(fixes.len(), 1);
+        match &fixes[0] {
+            LintCorrection::Insert(fix) => {
+                assert_eq!(fix.text, "\n");
+                assert_eq!(fix.location.start.row, 1);
+                assert_eq!(fix.location.start.column, 0);
+            }
+            _ => panic!("Expected Insert fix"),
+        }
     }
 
     #[test]
@@ -607,7 +672,8 @@ This is the content.
             .parse_result
             .ast()
             .children()
-            .unwrap().first()
+            .unwrap()
+            .first()
             .unwrap();
         let result = rule.check(admonition, &context, LintLevel::Error);
 

--- a/src/rules/rule007_no_headings_in_admonitions.rs
+++ b/src/rules/rule007_no_headings_in_admonitions.rs
@@ -1,0 +1,241 @@
+use markdown::mdast::Node;
+use supa_mdx_macros::RuleName;
+
+use crate::{
+    context::Context,
+    errors::{LintError, LintLevel},
+};
+
+use super::{Rule, RuleName, RuleSettings};
+
+const MESSAGE: &str =
+    "Admonitions cannot contain headings. Use the `title` prop for a callout title, or move the heading and section content outside the Admonition.";
+
+/// Admonitions are callouts and asides, not document sections.
+///
+/// Use the `title` prop for an optional callout title. Move content that needs
+/// structural headings into the surrounding document.
+#[derive(Debug, Default, RuleName)]
+pub struct Rule007NoHeadingsInAdmonitions;
+
+impl Rule for Rule007NoHeadingsInAdmonitions {
+    fn default_level(&self) -> LintLevel {
+        LintLevel::Error
+    }
+
+    fn setup(&mut self, _settings: Option<&mut RuleSettings>) {}
+
+    fn check(&self, ast: &Node, context: &Context, level: LintLevel) -> Option<Vec<LintError>> {
+        let Node::MdxJsxFlowElement(element) = ast else {
+            return None;
+        };
+
+        if !element
+            .name
+            .as_ref()
+            .is_some_and(|name| name == "Admonition")
+        {
+            return None;
+        }
+
+        let mut headings = Vec::new();
+        for child in &element.children {
+            collect_heading_nodes(child, &mut headings);
+        }
+
+        let errors = headings
+            .into_iter()
+            .filter_map(|heading| {
+                LintError::from_node()
+                    .node(heading)
+                    .context(context)
+                    .rule(self.name())
+                    .level(level)
+                    .message(MESSAGE)
+                    .call()
+            })
+            .collect::<Vec<_>>();
+
+        (!errors.is_empty()).then_some(errors)
+    }
+}
+
+fn collect_heading_nodes<'node>(node: &'node Node, headings: &mut Vec<&'node Node>) {
+    if is_heading(node) {
+        headings.push(node);
+    }
+
+    // Let a nested Admonition report its own headings to avoid duplicate errors.
+    if is_admonition(node) {
+        return;
+    }
+
+    if let Some(children) = node.children() {
+        for child in children {
+            collect_heading_nodes(child, headings);
+        }
+    }
+}
+
+fn is_heading(node: &Node) -> bool {
+    match node {
+        Node::Heading(_) => true,
+        Node::MdxJsxFlowElement(element) => element.name.as_deref().is_some_and(is_html_heading),
+        Node::MdxJsxTextElement(element) => element.name.as_deref().is_some_and(is_html_heading),
+        _ => false,
+    }
+}
+
+fn is_admonition(node: &Node) -> bool {
+    matches!(
+        node,
+        Node::MdxJsxFlowElement(element)
+            if element.name.as_ref().is_some_and(|name| name == "Admonition")
+    )
+}
+
+fn is_html_heading(name: &str) -> bool {
+    matches!(name, "h1" | "h2" | "h3" | "h4" | "h5" | "h6")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{context::Context, parser::parse};
+
+    fn check(mdx: &str) -> Option<Vec<LintError>> {
+        let parse_result = parse(mdx).unwrap();
+        let context = Context::builder()
+            .parse_result(&parse_result)
+            .build()
+            .unwrap();
+        let admonition = context
+            .parse_result
+            .ast()
+            .children()
+            .unwrap()
+            .iter()
+            .find(|node| {
+                matches!(
+                    node,
+                    Node::MdxJsxFlowElement(element)
+                        if element.name.as_ref().is_some_and(|name| name == "Admonition")
+                )
+            })
+            .unwrap();
+
+        Rule007NoHeadingsInAdmonitions.check(admonition, &context, LintLevel::Error)
+    }
+
+    #[test]
+    fn rejects_all_markdown_heading_levels() {
+        for level in 1..=6 {
+            let mdx = format!(
+                "<Admonition type=\"note\">\n\n{} Title\n\nBody.\n\n</Admonition>",
+                "#".repeat(level)
+            );
+            let errors = check(&mdx).unwrap();
+
+            assert_eq!(errors.len(), 1, "expected h{level} to be rejected");
+            assert_eq!(errors[0].location.start.row, 2);
+            assert_eq!(errors[0].location.start.column, 0);
+            assert_eq!(errors[0].message(), MESSAGE);
+            assert!(errors[0].fix.is_none());
+        }
+    }
+
+    #[test]
+    fn rejects_all_jsx_heading_elements() {
+        for level in 1..=6 {
+            let mdx = format!(
+                "<Admonition type=\"note\">\n\n<h{level}>Title</h{level}>\n\n</Admonition>"
+            );
+            let errors = check(&mdx).unwrap();
+
+            assert_eq!(errors.len(), 1, "expected <h{level}> to be rejected");
+            assert_eq!(errors[0].location.start.row, 2);
+            assert_eq!(errors[0].location.start.column, 0);
+        }
+    }
+
+    #[test]
+    fn rejects_nested_headings() {
+        let errors = check(
+            r#"<Admonition type="note">
+
+<div>
+
+### Nested title
+
+</div>
+
+</Admonition>"#,
+        )
+        .unwrap();
+
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].location.start.row, 4);
+    }
+
+    #[test]
+    fn allows_title_and_rich_body_content() {
+        let result = check(
+            r#"<Admonition type="note" title="Optional title">
+
+Body copy with [a link](/docs), `inline code`, and a list:
+
+- First item
+- Second item
+
+</Admonition>"#,
+        );
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn allows_heading_syntax_in_code_fences() {
+        let result = check(
+            r#"<Admonition type="note">
+
+```md
+### Example heading
+```
+
+</Admonition>"#,
+        );
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn ignores_headings_outside_admonitions() {
+        let mdx = r#"## Document section
+
+<Admonition type="note">
+
+Body copy.
+
+</Admonition>"#;
+
+        assert!(check(mdx).is_none());
+    }
+
+    #[test]
+    fn reports_each_heading_in_an_admonition() {
+        let errors = check(
+            r#"<Admonition type="note">
+
+## First heading
+
+### Second heading
+
+</Admonition>"#,
+        )
+        .unwrap();
+
+        assert_eq!(errors.len(), 2);
+        assert_eq!(errors[0].location.start.row, 2);
+        assert_eq!(errors[1].location.start.row, 4);
+    }
+}

--- a/src/snapshots/supa_mdx_lint__tests__public_api.snap
+++ b/src/snapshots/supa_mdx_lint__tests__public_api.snap
@@ -593,6 +593,34 @@ pub fn supa_mdx_lint::rules::Rule006NoAbsoluteUrls::borrow_mut(&mut self) -> &mu
 impl<T> core::convert::From<T> for supa_mdx_lint::rules::Rule006NoAbsoluteUrls
 pub fn supa_mdx_lint::rules::Rule006NoAbsoluteUrls::from(t: T) -> T
 impl<T> either::into_either::IntoEither for supa_mdx_lint::rules::Rule006NoAbsoluteUrls
+pub struct supa_mdx_lint::rules::Rule007NoHeadingsInAdmonitions
+impl core::default::Default for supa_mdx_lint::rules::Rule007NoHeadingsInAdmonitions
+pub fn supa_mdx_lint::rules::Rule007NoHeadingsInAdmonitions::default() -> supa_mdx_lint::rules::Rule007NoHeadingsInAdmonitions
+impl core::fmt::Debug for supa_mdx_lint::rules::Rule007NoHeadingsInAdmonitions
+pub fn supa_mdx_lint::rules::Rule007NoHeadingsInAdmonitions::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for supa_mdx_lint::rules::Rule007NoHeadingsInAdmonitions
+impl core::marker::Send for supa_mdx_lint::rules::Rule007NoHeadingsInAdmonitions
+impl core::marker::Sync for supa_mdx_lint::rules::Rule007NoHeadingsInAdmonitions
+impl core::marker::Unpin for supa_mdx_lint::rules::Rule007NoHeadingsInAdmonitions
+impl core::panic::unwind_safe::RefUnwindSafe for supa_mdx_lint::rules::Rule007NoHeadingsInAdmonitions
+impl core::panic::unwind_safe::UnwindSafe for supa_mdx_lint::rules::Rule007NoHeadingsInAdmonitions
+impl<T, U> core::convert::Into<U> for supa_mdx_lint::rules::Rule007NoHeadingsInAdmonitions where U: core::convert::From<T>
+pub fn supa_mdx_lint::rules::Rule007NoHeadingsInAdmonitions::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for supa_mdx_lint::rules::Rule007NoHeadingsInAdmonitions where U: core::convert::Into<T>
+pub type supa_mdx_lint::rules::Rule007NoHeadingsInAdmonitions::Error = core::convert::Infallible
+pub fn supa_mdx_lint::rules::Rule007NoHeadingsInAdmonitions::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for supa_mdx_lint::rules::Rule007NoHeadingsInAdmonitions where U: core::convert::TryFrom<T>
+pub type supa_mdx_lint::rules::Rule007NoHeadingsInAdmonitions::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn supa_mdx_lint::rules::Rule007NoHeadingsInAdmonitions::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for supa_mdx_lint::rules::Rule007NoHeadingsInAdmonitions where T: 'static + ?core::marker::Sized
+pub fn supa_mdx_lint::rules::Rule007NoHeadingsInAdmonitions::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for supa_mdx_lint::rules::Rule007NoHeadingsInAdmonitions where T: ?core::marker::Sized
+pub fn supa_mdx_lint::rules::Rule007NoHeadingsInAdmonitions::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for supa_mdx_lint::rules::Rule007NoHeadingsInAdmonitions where T: ?core::marker::Sized
+pub fn supa_mdx_lint::rules::Rule007NoHeadingsInAdmonitions::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for supa_mdx_lint::rules::Rule007NoHeadingsInAdmonitions
+pub fn supa_mdx_lint::rules::Rule007NoHeadingsInAdmonitions::from(t: T) -> T
+impl<T> either::into_either::IntoEither for supa_mdx_lint::rules::Rule007NoHeadingsInAdmonitions
 pub enum supa_mdx_lint::LintLevel
 pub supa_mdx_lint::LintLevel::Error
 pub supa_mdx_lint::LintLevel::Warning

--- a/tests/autofix_tests.rs
+++ b/tests/autofix_tests.rs
@@ -157,6 +157,26 @@ This one is missing the opening newline.
 }
 
 #[test]
+fn test_autofix_rule005_opening_newline_with_trailing_whitespace() {
+    let tempdir = TempDir::new().unwrap();
+    let bad_file = "<Admonition type=\"note\">  \t\nBody.\n\n</Admonition>";
+    fs::write(tempdir.path().join("bad.mdx"), bad_file).unwrap();
+
+    let mut cmd = Command::cargo_bin("supa-mdx-lint").unwrap();
+    cmd.arg(tempdir.path().join("bad.mdx"))
+        .arg("--config")
+        .arg("tests/supa-mdx-lint.config.toml")
+        .arg("--fix");
+    cmd.assert().success();
+
+    let result = fs::read_to_string(tempdir.path().join("bad.mdx")).unwrap();
+    assert_eq!(
+        result,
+        "<Admonition type=\"note\">  \t\n\nBody.\n\n</Admonition>"
+    );
+}
+
+#[test]
 fn test_autofix_rule005_admonition_newlines_with_frontmatter() {
     let tempdir = TempDir::new().unwrap();
     let bad_file = r#"---

--- a/tests/rule007/jsx_heading.mdx
+++ b/tests/rule007/jsx_heading.mdx
@@ -1,0 +1,5 @@
+<Admonition type="caution">
+
+<h4>Invalid JSX heading</h4>
+
+</Admonition>

--- a/tests/rule007/markdown_heading.mdx
+++ b/tests/rule007/markdown_heading.mdx
@@ -1,0 +1,5 @@
+<Admonition type="caution">
+
+### Invalid Markdown heading
+
+</Admonition>

--- a/tests/rule007/mod.rs
+++ b/tests/rule007/mod.rs
@@ -1,0 +1,19 @@
+use std::process::Command;
+
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+
+#[test]
+fn integration_test_rule007_reports_headings_in_admonitions() {
+    let mut cmd = Command::cargo_bin("supa-mdx-lint").unwrap();
+    cmd.arg("tests/rule007/rule007.mdx")
+        .arg("--config")
+        .arg("tests/rule007/supa-mdx-lint.config.toml");
+
+    cmd.assert()
+        .failure()
+        .stdout(predicate::str::contains("2 errors"))
+        .stdout(predicate::str::contains(
+            "Admonitions cannot contain headings. Use the `title` prop for a callout title, or move the heading and section content outside the Admonition.",
+        ));
+}

--- a/tests/rule007/mod.rs
+++ b/tests/rule007/mod.rs
@@ -3,6 +3,21 @@ use std::process::Command;
 use assert_cmd::prelude::*;
 use predicates::prelude::*;
 
+fn assert_heading_error(fixture: &str, expected_location: &str) {
+    let mut cmd = Command::cargo_bin("supa-mdx-lint").unwrap();
+    cmd.arg(fixture)
+        .arg("--config")
+        .arg("tests/rule007/supa-mdx-lint.config.toml");
+
+    cmd.assert()
+        .failure()
+        .stdout(predicate::str::contains("1 error"))
+        .stdout(predicate::str::contains(expected_location))
+        .stdout(predicate::str::contains(
+            "Admonitions cannot contain headings. Use the `title` prop for a callout title, or move the heading and section content outside the Admonition.",
+        ));
+}
+
 #[test]
 fn integration_test_rule007_reports_headings_in_admonitions() {
     let mut cmd = Command::cargo_bin("supa-mdx-lint").unwrap();
@@ -16,4 +31,20 @@ fn integration_test_rule007_reports_headings_in_admonitions() {
         .stdout(predicate::str::contains(
             "Admonitions cannot contain headings. Use the `title` prop for a callout title, or move the heading and section content outside the Admonition.",
         ));
+}
+
+#[test]
+fn integration_test_rule007_reports_markdown_heading() {
+    assert_heading_error(
+        "tests/rule007/markdown_heading.mdx",
+        "tests/rule007/markdown_heading.mdx:3:1",
+    );
+}
+
+#[test]
+fn integration_test_rule007_reports_jsx_heading() {
+    assert_heading_error(
+        "tests/rule007/jsx_heading.mdx",
+        "tests/rule007/jsx_heading.mdx:3:1",
+    );
 }

--- a/tests/rule007/rule007.mdx
+++ b/tests/rule007/rule007.mdx
@@ -1,0 +1,17 @@
+## Valid document heading
+
+<Admonition type="note" title="Valid title">
+
+Rich body content remains valid.
+
+</Admonition>
+
+<Admonition type="caution">
+
+### Invalid Markdown heading
+
+Body copy.
+
+<h4>Invalid JSX heading</h4>
+
+</Admonition>

--- a/tests/rule007/supa-mdx-lint.config.toml
+++ b/tests/rule007/supa-mdx-lint.config.toml
@@ -1,0 +1,7 @@
+Rule001HeadingCase = false
+Rule002AdmonitionTypes = false
+Rule003Spelling = false
+Rule004ExcludeWords = false
+Rule005AdmonitionNewlines = false
+Rule006NoAbsoluteUrls = false
+Rule007NoHeadingsInAdmonitions = true

--- a/tests/rules.rs
+++ b/tests/rules.rs
@@ -3,3 +3,4 @@ mod rule002;
 mod rule003;
 mod rule004;
 mod rule006;
+mod rule007;


### PR DESCRIPTION
## What changed

- add an error-level `Rule007NoHeadingsInAdmonitions`
- reject Markdown headings and JSX `h1`–`h6` descendants inside `Admonition`
- report each heading precisely without offering an unsafe autofix
- allow headings outside admonitions, `title` props, rich body content, and heading-like text in code fences
- make Rule005 recognise multiline JSX attributes such as `actions={...}`

## Why

Admonitions are callouts and asides rather than document sections. Structural headings inside them inherit prose spacing and produce awkward layouts. Authors should use the existing `title` prop for a callout label or move a real section outside the admonition.

## Validation

- `cargo test --all-targets`
- ran the resulting binary across the Supabase Docs content tree
